### PR TITLE
Improve compatibility with old Magento version

### DIFF
--- a/Model/CheckItemsQuantity.php
+++ b/Model/CheckItemsQuantity.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace MageWorx\OrderEditorInventory\Model;
+
+use Magento\Framework\Exception\BulkException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\InventorySalesApi\Api\Data\ProductSalabilityErrorInterface;
+use Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface;
+
+class CheckItemsQuantity
+{
+    /**
+     * @var IsProductSalableForRequestedQtyInterface
+     */
+    private $isProductSalableForRequestedQty;
+
+    /**
+     * @param IsProductSalableForRequestedQtyInterface $isProductSalableForRequestedQty
+     */
+    public function __construct(
+        IsProductSalableForRequestedQtyInterface $isProductSalableForRequestedQty
+    ) {
+        $this->isProductSalableForRequestedQty = $isProductSalableForRequestedQty;
+    }
+
+    /**
+     * Check whether all items salable
+     *
+     * @param array $items [['sku' => 'qty'], ...]
+     * @param int $stockId
+     * @return void
+     * @throws LocalizedException
+     */
+    public function execute(array $items, int $stockId): void
+    {
+        $bulkException = new BulkException();
+
+        foreach ($items as $sku => $qty) {
+            $isSalable = $this->isProductSalableForRequestedQty->execute((string)$sku, $stockId, (float)$qty);
+            if (false === $isSalable->isSalable()) {
+                $errors = $isSalable->getErrors();
+                /** @var ProductSalabilityErrorInterface $errorMessage */
+                $errorMessage = array_pop($errors);
+
+                $bulkException->addException(new LocalizedException(__($errorMessage->getMessage())));
+            }
+        }
+
+        if ($bulkException->wasErrorAdded()) {
+            throw $bulkException;
+        }
+    }
+}

--- a/Model/StockQtyManager.php
+++ b/Model/StockQtyManager.php
@@ -14,7 +14,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface;
 use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
 use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForProductTypeInterface;
-use Magento\InventorySales\Model\CheckItemsQuantity;
+use MageWorx\OrderEditorInventory\Model\CheckItemsQuantity;
 use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,14 @@
     "description": "Order Editor Inventory Plugin",
     "require": {
         "mageworx/module-ordereditorbase": ">=2.9.7",
-        "magento/module-inventory": ">=1.2.0"
+        "magento/module-inventory-api": "^1.0",
+        "magento/module-inventory-sales-api": "^1.0",
+        "magento/module-inventory-catalog-api": "^1.0",
+        "magento/module-inventory-configuration-api": "^1.0",
+        "magento/module-inventory-source-deduction-api": "^1.0"
     },
     "type": "magento2-module",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -9,7 +9,11 @@
     <module name="MageWorx_OrderEditorInventory" setup_version="1.0.0">
         <sequence>
             <module name="MageWorx_OrderEditor"/>
-            <module name="Magento_Inventory"/>
+            <module name="Magento_InventoryApi"/>
+            <module name="Magento_InventorySalesApi"/>
+            <module name="Magento_InventoryCatalogApi"/>
+            <module name="Magento_InventoryConfigurationApi"/>
+            <module name="Magento_InventorySourceDeductionApi"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
subj.

New requirements are based on the api modules only. The `GetSalesChannelForOrder` class has been removed from codebase.