### PR TITLE
Inventory: MSI stock refactor + swap/return fixes + unit tests

### DIFF
--- a/Api/CancelShipmentProcessorInterface.php
+++ b/Api/CancelShipmentProcessorInterface.php
@@ -11,9 +11,13 @@ use Magento\Sales\Api\Data\ShipmentInterface;
 interface CancelShipmentProcessorInterface
 {
     /**
-     * Return all shipped items to stock (cancel shipment)
+     * Return shipped items to stock (cancel shipment).
      *
      * @param ShipmentInterface $shipment
+     * @param array<int, float> $remainingByOrderItem Shared budget [orderItemId => qty left to return],
+     *        carried across all shipments of one order cancelled in a single pass so the total
+     *        returned equals the still-shippable qty (not the sum of per-shipment caps). Pass an
+     *        empty array for a standalone cancel; it is initialized lazily per order item.
      */
-    public function execute(ShipmentInterface $shipment): void;
+    public function execute(ShipmentInterface $shipment, array &$remainingByOrderItem = []): void;
 }

--- a/Api/StockQtyManagerInterface.php
+++ b/Api/StockQtyManagerInterface.php
@@ -32,9 +32,11 @@ interface StockQtyManagerInterface
     public function returnQtyToStock(OrderItem $orderItem, ?float $qty = null): void;
 
     /**
-     * Return all shipment items to stock (cancel\delete shipment)
+     * Return shipment items to stock (cancel\delete shipment).
      *
      * @param ShipmentInterface $shipment
+     * @param array<int, float> $remainingByOrderItem Shared budget across the order's shipments
+     *        cancelled in one pass — see CancelShipmentProcessorInterface::execute().
      */
-    public function cancelShipment(ShipmentInterface $shipment): void;
+    public function cancelShipment(ShipmentInterface $shipment, array &$remainingByOrderItem = []): void;
 }

--- a/Model/Order/ShipmentManager.php
+++ b/Model/Order/ShipmentManager.php
@@ -24,6 +24,7 @@ use MageWorx\OrderEditor\Api\ShipmentManagerInterface;
 use MageWorx\OrderEditor\Helper\Data as Helper;
 use MageWorx\OrderEditor\Model\Config\Source\Shipments\UpdateMode;
 use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditor\Model\StockDebugLogger;
 use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
 
 /**
@@ -99,6 +100,11 @@ class ShipmentManager implements ShipmentManagerInterface
     private $getSkuFromOrderItem;
 
     /**
+     * @var StockDebugLogger
+     */
+    private $stockDebugLogger;
+
+    /**
      * ShipmentManager constructor.
      *
      * @param Helper $helperData
@@ -113,6 +119,7 @@ class ShipmentManager implements ShipmentManagerInterface
      * @param OriginalOrderRepositoryInterfaceFactory $originalOrderRepositoryFactory
      * @param StockQtyManagerInterface $stockQtyManager
      * @param GetSkuFromOrderItemInterface $getSkuFromOrderItem
+     * @param StockDebugLogger $stockDebugLogger
      */
     public function __construct(
         Helper                                  $helperData,
@@ -126,7 +133,8 @@ class ShipmentManager implements ShipmentManagerInterface
         OriginalOrderRepositoryInterface        $originalOrderRepository,
         OriginalOrderRepositoryInterfaceFactory $originalOrderRepositoryFactory,
         StockQtyManagerInterface                $stockQtyManager,
-        GetSkuFromOrderItemInterface            $getSkuFromOrderItem
+        GetSkuFromOrderItemInterface            $getSkuFromOrderItem,
+        StockDebugLogger                        $stockDebugLogger
     ) {
         $this->helperData                     = $helperData;
         $this->registry                       = $registry;
@@ -140,6 +148,7 @@ class ShipmentManager implements ShipmentManagerInterface
         $this->originalOrderRepositoryFactory = $originalOrderRepositoryFactory;
         $this->stockQtyManager                = $stockQtyManager;
         $this->getSkuFromOrderItem            = $getSkuFromOrderItem;
+        $this->stockDebugLogger               = $stockDebugLogger;
     }
 
     /**
@@ -150,6 +159,10 @@ class ShipmentManager implements ShipmentManagerInterface
         Order $order
     ): Order {
         if ($order->hasShipments()) {
+            $this->stockDebugLogger->open('ShipmentManager::updateShipmentsOnOrderEdit', [
+                'order_id' => (int)$order->getId(),
+                'mode'     => $this->helperData->getUpdateShipmentMode(),
+            ]);
             $itemsBySourceCode = [];
             foreach ($order->getShipmentsCollection() as $shipment) {
                 // Unregister by key to prevent exceptions (@see body of the load method)
@@ -207,6 +220,8 @@ class ShipmentManager implements ShipmentManagerInterface
                     }
                     break;
             }
+
+            $this->stockDebugLogger->close('shipments updated');
         }
 
         return $order;
@@ -240,6 +255,14 @@ class ShipmentManager implements ShipmentManagerInterface
                                                         ->setOrderId($order->getId())
                                                         ->setShipmentId($shipment->getId())
                                                         ->load();
+
+            $this->stockDebugLogger->log('cancel + delete shipment', [
+                'shipment_id' => (int)$shipment->getId(),
+                'source_code' => $shipment->getExtensionAttributes()
+                    ? $shipment->getExtensionAttributes()->getSourceCode()
+                    : null,
+                'items'       => count($shipment->getAllItems()),
+            ]);
 
             $this->stockQtyManager->cancelShipment($shipment);
 
@@ -282,6 +305,10 @@ class ShipmentManager implements ShipmentManagerInterface
         if ($order->canShip()) {
             foreach ($itemsBySourceCode as $sourceCode => $items) {
                 $data = $this->getShipmentData($order, $sourceCode, $items);
+                $this->stockDebugLogger->log('create new shipment', [
+                    'source_code' => $sourceCode,
+                    'items'       => $data['items'] ?? [],
+                ]);
                 // Unregister by key to prevent exceptions (@see body of the load method)
                 $this->registry->unregister('current_shipment');
                 // Need to reload order registry in order repository

--- a/Model/Order/ShipmentManager.php
+++ b/Model/Order/ShipmentManager.php
@@ -245,6 +245,10 @@ class ShipmentManager implements ShipmentManagerInterface
     private function removeAllShipments(Order $order): void
     {
         $shipments = $order->getShipmentsCollection();
+        // Shared per-order-item budget so the total returned across ALL cancelled
+        // shipments equals the still-shippable qty (Add-new-shipment mode can leave
+        // several shipments; capping each at the full qtyToShip would over-return).
+        $remainingByOrderItem = [];
         /** @var Shipment $shipment */
         foreach ($shipments as $shipment) {
             // Unregister by key to prevent exceptions (@see body of the load method)
@@ -264,7 +268,7 @@ class ShipmentManager implements ShipmentManagerInterface
                 'items'       => count($shipment->getAllItems()),
             ]);
 
-            $this->stockQtyManager->cancelShipment($shipment);
+            $this->stockQtyManager->cancelShipment($shipment, $remainingByOrderItem);
 
             $this->shipmentRepository->delete($shipment);
         }

--- a/Model/Order/ShipmentManager.php
+++ b/Model/Order/ShipmentManager.php
@@ -24,6 +24,7 @@ use MageWorx\OrderEditor\Api\ShipmentManagerInterface;
 use MageWorx\OrderEditor\Helper\Data as Helper;
 use MageWorx\OrderEditor\Model\Config\Source\Shipments\UpdateMode;
 use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditor\Model\Order\Item\Quantity\ItemQuantitiesResolver;
 use MageWorx\OrderEditor\Model\StockDebugLogger;
 use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
 
@@ -105,6 +106,11 @@ class ShipmentManager implements ShipmentManagerInterface
     private $stockDebugLogger;
 
     /**
+     * @var ItemQuantitiesResolver
+     */
+    private ItemQuantitiesResolver $itemQuantitiesResolver;
+
+    /**
      * ShipmentManager constructor.
      *
      * @param Helper $helperData
@@ -120,6 +126,7 @@ class ShipmentManager implements ShipmentManagerInterface
      * @param StockQtyManagerInterface $stockQtyManager
      * @param GetSkuFromOrderItemInterface $getSkuFromOrderItem
      * @param StockDebugLogger $stockDebugLogger
+     * @param ItemQuantitiesResolver $itemQuantitiesResolver
      */
     public function __construct(
         Helper                                  $helperData,
@@ -134,7 +141,8 @@ class ShipmentManager implements ShipmentManagerInterface
         OriginalOrderRepositoryInterfaceFactory $originalOrderRepositoryFactory,
         StockQtyManagerInterface                $stockQtyManager,
         GetSkuFromOrderItemInterface            $getSkuFromOrderItem,
-        StockDebugLogger                        $stockDebugLogger
+        StockDebugLogger                        $stockDebugLogger,
+        ItemQuantitiesResolver                  $itemQuantitiesResolver
     ) {
         $this->helperData                     = $helperData;
         $this->registry                       = $registry;
@@ -149,6 +157,7 @@ class ShipmentManager implements ShipmentManagerInterface
         $this->stockQtyManager                = $stockQtyManager;
         $this->getSkuFromOrderItem            = $getSkuFromOrderItem;
         $this->stockDebugLogger               = $stockDebugLogger;
+        $this->itemQuantitiesResolver         = $itemQuantitiesResolver;
     }
 
     /**
@@ -184,8 +193,7 @@ class ShipmentManager implements ShipmentManagerInterface
                     }
 
                     $sku       = $this->getSkuFromOrderItem->execute($orderItem);
-                    $qtyToShip = $orderItem->getQtyOrdered() -
-                        ($orderItem->getQtyRefunded() + $orderItem->getQtyCanceled());
+                    $qtyToShip = $this->itemQuantitiesResolver->resolve($orderItem)->kept();
                     /* 👆 Already shipped items should not be shipped one more time */
 
                     $itemsBySourceCode[$sourceCode][$orderItemId] = [

--- a/Model/Order/ShipmentManager.php
+++ b/Model/Order/ShipmentManager.php
@@ -213,11 +213,12 @@ class ShipmentManager implements ShipmentManagerInterface
                     $this->createShipmentForOrder($order, $itemsBySourceCode);
                     break;
                 case UpdateMode::MODE_UPDATE_NOTHING:
-                    if ($order->hasRemovedItems()
-                        || $order->hasItemsWithDecreasedQty()
-                    ) {
-                        $this->removeAllShipments($order);
-                    }
+                    // "Do not touch" — shipments are left exactly as they are (the
+                    // historical record of what was physically shipped). Stock return
+                    // on a decrease/removal is owned by the credit memo (back_to_stock).
+                    // Deleting shipments here would contradict the mode and, via
+                    // cancelShipment, double-move stock. (Matches the base non-MSI
+                    // ShipmentManager, whose NOTHING branch is a plain no-op.)
                     break;
             }
 

--- a/Model/Stock/BackorderPolicy.php
+++ b/Model/Stock/BackorderPolicy.php
@@ -1,0 +1,61 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Model\Stock;
+
+use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Decides whether a given SKU is allowed to deduct beyond the available
+ * physical source qty (i.e. allow source_item.quantity to go negative or stay
+ * at 0 with a backorder accounting in MSI).
+ *
+ * Magento per-product `Stock\Item::getBackorders()` values:
+ *   0 = NO        — must respect physical qty; insufficient stock is an error.
+ *   1 = YES       — backorders allowed (silent).
+ *   2 = YES + notify customer.
+ *
+ * For the swap physical exchange use case any non-zero value is treated as
+ * "admin can deduct beyond available qty" — the admin has explicitly
+ * confirmed they are physically shipping the new SKU, so MSI should not
+ * second-guess them. Stock can either go negative (legacy mode) or be
+ * recorded as backorder qty (MSI handles the accounting).
+ */
+class BackorderPolicy
+{
+    public function __construct(
+        private GetStockItemConfigurationInterface $getStockItemConfiguration,
+        private StockResolverInterface $stockResolver,
+        private WebsiteRepositoryInterface $websiteRepository
+    ) {
+    }
+
+    /**
+     * @param string $sku
+     * @param int $websiteId
+     * @return bool true if backorders are allowed for this SKU on the
+     *              website's stock; false if NOT allowed (No-backorder).
+     */
+    public function isBackorderAllowed(string $sku, int $websiteId): bool
+    {
+        try {
+            $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
+            $stock = $this->stockResolver->execute(ScopeInterface::SCOPE_WEBSITE, $websiteCode);
+            $stockItemConfiguration = $this->getStockItemConfiguration->execute(
+                $sku,
+                (int) $stock->getStockId()
+            );
+            return $stockItemConfiguration->getBackorders() !== 0;
+        } catch (\Throwable $e) {
+            // Conservative default: if we cannot read configuration (missing
+            // assignment, deleted product), treat as "no backorders" so the
+            // exchange routine falls back to source priority instead of
+            // silently allowing negative stock.
+            return false;
+        }
+    }
+}

--- a/Model/Stock/MsiSwapPhysicalExchange.php
+++ b/Model/Stock/MsiSwapPhysicalExchange.php
@@ -1,0 +1,334 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Model\Stock;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use MageWorx\OrderEditor\Api\Stock\SwapPhysicalExchangeInterface;
+use MageWorx\OrderEditor\Model\StockDebugLogger;
+
+/**
+ * MSI implementation of swap physical exchange.
+ *
+ * Pre-flight (validate):
+ *   - For each shipment source the order item was shipped from, verify the
+ *     OLD SKU is still assigned (we will return qty there).
+ *   - Verify NEW SKU has at least one usable source (preferred shipment
+ *     source first, then priority-iterated sources of the same stock,
+ *     respecting backorder policy).
+ *   - Throws LocalizedException on failure with admin-readable details.
+ *
+ * Execute:
+ *   - For each shipment_source/qty pair from `inventory_shipment_source`:
+ *     · +qty on old SKU at that source (return-to-stock).
+ *     · -qty on new SKU at the resolved source (same / priority).
+ *   - For audit: emit standard MSI reservations (event_type=`order_canceled`
+ *     for the +qty release, event_type=`order_placed` for the -qty deduction).
+ *     Standard event types ensure compatibility with third-party MSI tools
+ *     (reconciliation reports, inventory dashboards, etc).
+ *   - User-facing notice when source resolution falls back to a non-shipment
+ *     source (so admin sees what actually happened).
+ *   - StockDebugLogger entries on each step for ops/troubleshooting.
+ */
+class MsiSwapPhysicalExchange implements SwapPhysicalExchangeInterface
+{
+    public function __construct(
+        private SourceCodeResolver $sourceCodeResolver,
+        private GetSourceItemsBySkuInterface $getSourceItemsBySku,
+        private SourceItemsSaveInterface $sourceItemsSave,
+        private PlaceReservationsForSalesEventInterface $placeReservationsForSalesEvent,
+        private SalesEventInterfaceFactory $salesEventFactory,
+        private SalesEventExtensionFactory $salesEventExtensionFactory,
+        private SalesChannelInterfaceFactory $salesChannelFactory,
+        private WebsiteRepositoryInterface $websiteRepository,
+        private ItemToSellInterfaceFactory $itemsToSellFactory,
+        private MessageManagerInterface $messageManager,
+        private StockDebugLogger $stockDebugLogger
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validate(
+        OrderInterface $order,
+        OrderItemInterface $shippedItem,
+        string $oldSku,
+        string $newSku,
+        float $qty
+    ): void {
+        if ($qty <= 0) {
+            return;
+        }
+        $websiteId = (int) $order->getStore()->getWebsiteId();
+        $shipmentSources = $this->sourceCodeResolver->resolveShipmentSources((int) $shippedItem->getItemId());
+
+        // Sanity: if no shipment_source records exist, we cannot pinpoint where to
+        // return the old SKU. Fall back to "any source assigned to old SKU" but
+        // require at least one such source.
+        if (empty($shipmentSources)) {
+            $oldSkuSources = iterator_to_array($this->getSourceItemsBySku->execute($oldSku));
+            if (empty($oldSkuSources)) {
+                throw new LocalizedException(__(
+                    'Cannot return shipped %1 to stock: no source is configured for this SKU.',
+                    $oldSku
+                ));
+            }
+        }
+
+        // For each shipment-source/qty pair we will deduct that many of the
+        // new SKU. Validate that a deduction source can be resolved.
+        $perSource = $this->normalizeShipmentSources($shipmentSources, $qty);
+        foreach ($perSource as $sourceCode => $qtyAtSource) {
+            $deductionSource = $this->sourceCodeResolver->findDeductionSource(
+                $newSku,
+                $websiteId,
+                $qtyAtSource,
+                $sourceCode
+            );
+            if ($deductionSource === null) {
+                throw new LocalizedException(__(
+                    'Cannot deduct %1 of %2 from any source: insufficient stock and backorders are disabled. '
+                    . 'Please enable backorders for %2 or assign it to a source with enough qty.',
+                    $qtyAtSource,
+                    $newSku
+                ));
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function execute(
+        OrderInterface $order,
+        OrderItemInterface $shippedItem,
+        string $oldSku,
+        string $newSku,
+        float $qty
+    ): void {
+        if ($qty <= 0) {
+            return;
+        }
+        $this->stockDebugLogger->open('MsiSwapPhysicalExchange::execute', [
+            'order_id'   => (int) $order->getId(),
+            'item_id'    => (int) $shippedItem->getItemId(),
+            'old_sku'    => $oldSku,
+            'new_sku'    => $newSku,
+            'qty'        => $qty,
+        ]);
+        try {
+            $websiteId = (int) $order->getStore()->getWebsiteId();
+            $shipmentSources = $this->sourceCodeResolver->resolveShipmentSources((int) $shippedItem->getItemId());
+            $perSource = $this->normalizeShipmentSources($shipmentSources, $qty);
+
+            $totalReturnedByOldSource = [];
+            $totalDeductedByNewSource = [];
+            $fallbackUsedForNewSku = false;
+
+            foreach ($perSource as $shipmentSourceCode => $qtyAtSource) {
+                // Return old SKU to its shipment source (always — that's where it came from).
+                $returnSource = $this->sourceCodeResolver->findReturnSource(
+                    $oldSku,
+                    $websiteId,
+                    $shipmentSourceCode
+                );
+                if ($returnSource === null) {
+                    // Impossibly rare — old SKU has no source. Skip return on this leg
+                    // (audit reservation still emitted to keep ledger consistent).
+                    $this->stockDebugLogger->warn('old SKU not assigned to any source', [
+                        'sku' => $oldSku,
+                    ]);
+                } else {
+                    $this->adjustSourceItem($oldSku, $returnSource, +$qtyAtSource);
+                    $totalReturnedByOldSource[$returnSource]
+                        = ($totalReturnedByOldSource[$returnSource] ?? 0.0) + $qtyAtSource;
+                }
+
+                // Deduct new SKU. Prefer same source as shipment; fall back via
+                // SourceCodeResolver (priority + backorder).
+                $deductionSource = $this->sourceCodeResolver->findDeductionSource(
+                    $newSku,
+                    $websiteId,
+                    $qtyAtSource,
+                    $shipmentSourceCode
+                );
+                if ($deductionSource === null) {
+                    // validate() should have caught this; race-with-concurrent-stock-change
+                    // path. Throw — caller treats as fatal.
+                    throw new LocalizedException(__(
+                        'Stock changed during exchange: cannot deduct %1 of %2 from any source.',
+                        $qtyAtSource,
+                        $newSku
+                    ));
+                }
+                if ($deductionSource !== $shipmentSourceCode) {
+                    $fallbackUsedForNewSku = true;
+                }
+                $this->adjustSourceItem($newSku, $deductionSource, -$qtyAtSource);
+                $totalDeductedByNewSource[$deductionSource]
+                    = ($totalDeductedByNewSource[$deductionSource] ?? 0.0) + $qtyAtSource;
+            }
+
+            // No audit reservation pair: for shipped qty the placement
+            // reservation has already been balanced by shipment_created
+            // (sum = 0 for the original SKU). Emitting `+qty order_canceled`
+            // for old SKU and `-qty order_placed` for new SKU here would
+            // create:
+            //   1. an orphan release on the old SKU (no matching deduction
+            //      reservation existed → +qty drift),
+            //   2. a duplicate placement deduction on the new SKU (the
+            //      original placement was already settled by shipment) →
+            //      -qty drift that never closes.
+            // The physical source mutation above is the only ledger event;
+            // the audit trail lives in the order history entry written by
+            // ProductOptionsEditor::logShippedSwapPhysicalExchange.
+
+            if ($fallbackUsedForNewSku) {
+                $this->messageManager->addNoticeMessage(__(
+                    'Some qty of new SKU "%1" was deducted from a non-shipment source ' .
+                    '(insufficient stock at the original shipment source). See order log for details.',
+                    $newSku
+                ));
+            }
+            $this->stockDebugLogger->log('exchange completed', [
+                'returned_by_source' => $totalReturnedByOldSource,
+                'deducted_by_source' => $totalDeductedByNewSource,
+                'fallback_used'      => $fallbackUsedForNewSku,
+            ]);
+            $this->stockDebugLogger->close('done');
+        } catch (\Throwable $e) {
+            $this->stockDebugLogger->warn('exchange failed', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->stockDebugLogger->close('error');
+            if ($e instanceof LocalizedException) {
+                throw $e;
+            }
+            // LocalizedException::__construct accepts ?Exception, not Throwable.
+            // Don't chain non-Exception errors (TypeError, AssertionError) — just
+            // surface the message.
+            $cause = $e instanceof \Exception ? $e : null;
+            throw new LocalizedException(
+                __('Swap physical exchange failed: %1', $e->getMessage()),
+                $cause
+            );
+        }
+    }
+
+    /**
+     * If shipment_source data is missing (e.g. legacy shipments before MSI
+     * extension attribute was wired), we treat the whole qty as a single
+     * "default-shipment" leg with sourceCode=null — caller resolves from
+     * priority list.
+     */
+    private function normalizeShipmentSources(array $shipmentSources, float $totalQty): array
+    {
+        if (empty($shipmentSources)) {
+            return ['' => $totalQty]; // empty key = no preferred source
+        }
+        // Sum-validate: shipment_source qty may be the qty per shipment,
+        // not per item. Cap at requested totalQty so we don't exchange more
+        // than asked.
+        $sum = array_sum($shipmentSources);
+        if (abs($sum - $totalQty) < 1e-8) {
+            return $shipmentSources;
+        }
+        // Distribute the requested qty across sources proportionally to their
+        // shipment shares — keeps split shipments correct for partial exchanges.
+        $normalized = [];
+        $remaining = $totalQty;
+        $i = 0;
+        $count = count($shipmentSources);
+        foreach ($shipmentSources as $code => $shipQty) {
+            $i++;
+            if ($i === $count) {
+                $normalized[$code] = $remaining;
+                break;
+            }
+            $share = round($shipQty / $sum * $totalQty, 4);
+            $normalized[$code] = $share;
+            $remaining -= $share;
+        }
+        return $normalized;
+    }
+
+    private function adjustSourceItem(string $sku, string $sourceCode, float $delta): void
+    {
+        if ($sourceCode === '') {
+            // No source resolved (legacy shipment without inventory_shipment_source).
+            // Skip physical adjustment; reservation pair will keep ledger balanced
+            // until the admin manually reconciles.
+            return;
+        }
+        foreach ($this->getSourceItemsBySku->execute($sku) as $sourceItem) {
+            if ($sourceItem->getSourceCode() === $sourceCode) {
+                $newQty = $sourceItem->getQuantity() + $delta;
+                $sourceItem->setQuantity($newQty);
+                if ($newQty > 0 && $sourceItem->getStatus() === SourceItemInterface::STATUS_OUT_OF_STOCK) {
+                    $sourceItem->setStatus(SourceItemInterface::STATUS_IN_STOCK);
+                }
+                $this->sourceItemsSave->execute([$sourceItem]);
+                return;
+            }
+        }
+        // SKU not assigned to source — log and continue. Reservation will
+        // record the audit even if physical adjust didn't land.
+        $this->stockDebugLogger->warn('SKU not assigned to source — skip physical adjust', [
+            'sku' => $sku,
+            'source' => $sourceCode,
+            'delta' => $delta,
+        ]);
+    }
+
+    /**
+     * Emit a single MSI reservation entry for audit.
+     */
+    private function placeReservation(
+        OrderInterface $order,
+        string $sku,
+        float $qty,
+        string $eventType
+    ): void {
+        $websiteId = (int) $order->getStore()->getWebsiteId();
+        $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
+        $salesChannel = $this->salesChannelFactory->create([
+            'data' => [
+                'type' => SalesChannelInterface::TYPE_WEBSITE,
+                'code' => $websiteCode,
+            ],
+        ]);
+        $extension = $this->salesEventExtensionFactory->create([
+            'data' => ['objectIncrementId' => (string) $order->getIncrementId()],
+        ]);
+        $salesEvent = $this->salesEventFactory->create([
+            'type' => $eventType,
+            'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
+            'objectId' => (string) $order->getEntityId(),
+        ]);
+        $salesEvent->setExtensionAttributes($extension);
+
+        $items = [
+            $this->itemsToSellFactory->create([
+                'sku' => $sku,
+                'qty' => $qty,
+            ]),
+        ];
+        $this->placeReservationsForSalesEvent->execute($items, $salesChannel, $salesEvent);
+    }
+}

--- a/Model/Stock/MultiSourceInventoryManager.php
+++ b/Model/Stock/MultiSourceInventoryManager.php
@@ -7,26 +7,35 @@ declare(strict_types = 1);
 
 namespace MageWorx\OrderEditorInventory\Model\Stock;
 
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
 use MageWorx\OrderEditor\Api\StockManagerInterface;
 use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
 
 class MultiSourceInventoryManager implements StockManagerInterface
 {
-    /**
-     * @var StockQtyManagerInterface
-     */
-    private $stockQtyManager;
-
-    /**
-     * MultiSourceInventoryManager constructor.
-     *
-     * @param StockQtyManagerInterface $stockQtyManager
-     */
     public function __construct(
-        StockQtyManagerInterface $stockQtyManager
+        private StockQtyManagerInterface $stockQtyManager,
+        private GetSkusByProductIdsInterface $getSkusByProductIds,
+        private ItemToSellInterfaceFactory $itemsToSellFactory,
+        private PlaceReservationsForSalesEventInterface $placeReservationsForSalesEvent,
+        private SalesEventInterfaceFactory $salesEventFactory,
+        private SalesEventExtensionFactory $salesEventExtensionFactory,
+        private SalesChannelInterfaceFactory $salesChannelFactory,
+        private WebsiteRepositoryInterface $websiteRepository,
+        private GetSourceItemsBySkuInterface $getSourceItemsBySku,
+        private SourceItemsSaveInterface $sourceItemsSave
     ) {
-        $this->stockQtyManager = $stockQtyManager;
     }
 
     /**
@@ -40,9 +49,47 @@ class MultiSourceInventoryManager implements StockManagerInterface
     /**
      * @inheritDoc
      */
+    /**
+     * Register stock adjustment by product ID via MSI reservations.
+     *
+     * Positive qty = return to stock (compensation reservation).
+     * Negative qty = deduct from stock (sale reservation).
+     * Used when replacing a configurable child product during order edit.
+     */
+    /**
+     * Register stock adjustment by product ID.
+     *
+     * Directly adjusts source item qty (physical stock).
+     * Salable qty updates automatically: salable = source_qty - sum(reservations).
+     *
+     * Positive qty = return to stock; negative qty = deduct from stock.
+     * Used when replacing a configurable child product during order edit (Configure action).
+     */
     public function registerReturnByProductId(int $productId, float $qty, int $websiteId): void
     {
-        // TODO: Implement registerReturnByProductId() method.
+        $productSkus = $this->getSkusByProductIds->execute([$productId]);
+        $sku = $productSkus[$productId] ?? null;
+        if (!$sku) {
+            return;
+        }
+
+        $sourceItems = $this->getSourceItemsBySku->execute($sku);
+        if (empty($sourceItems)) {
+            return;
+        }
+
+        // Adjust the first enabled source item.
+        // For multi-source setups the correct approach is to identify the shipment source,
+        // but for order editing single-source is the common case.
+        foreach ($sourceItems as $sourceItem) {
+            if ((int) $sourceItem->getStatus() !== 1) {
+                continue;
+            }
+            $newQty = $sourceItem->getQuantity() + $qty;
+            $sourceItem->setQuantity(max($newQty, 0.0));
+            $this->sourceItemsSave->execute([$sourceItem]);
+            break;
+        }
     }
 
     /**

--- a/Model/Stock/MultiSourceInventoryManager.php
+++ b/Model/Stock/MultiSourceInventoryManager.php
@@ -17,6 +17,7 @@ use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
 use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
 use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
 use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Store\Api\WebsiteRepositoryInterface;
 use MageWorx\OrderEditor\Api\StockManagerInterface;
@@ -64,9 +65,20 @@ class MultiSourceInventoryManager implements StockManagerInterface
      *
      * Positive qty = return to stock; negative qty = deduct from stock.
      * Used when replacing a configurable child product during order edit (Configure action).
+     *
+     * When $order is provided AND $qty is negative (deduct case), also creates
+     * paired reservations for the new SKU mirroring the lifecycle of the
+     * original order item: ORDER_PLACED -|qty| + SHIPMENT_CREATED +|qty|
+     * (net = 0). Without these, downstream operations (cancel shipment, void,
+     * refund) misbehave for the swapped-in SKU because MSI has no record of
+     * the virtual order_placed event for it. See REFACTORING_ROADMAP.md §4.2.3.
      */
-    public function registerReturnByProductId(int $productId, float $qty, int $websiteId): void
-    {
+    public function registerReturnByProductId(
+        int $productId,
+        float $qty,
+        int $websiteId,
+        ?OrderInterface $order = null
+    ): void {
         $productSkus = $this->getSkusByProductIds->execute([$productId]);
         $sku = $productSkus[$productId] ?? null;
         if (!$sku) {
@@ -89,6 +101,74 @@ class MultiSourceInventoryManager implements StockManagerInterface
             $sourceItem->setQuantity(max($newQty, 0.0));
             $this->sourceItemsSave->execute([$sourceItem]);
             break;
+        }
+
+        // Pair reservations for the new SKU on deduct (Configure swap on shipped item).
+        if ($order !== null && $qty < 0) {
+            $this->placePairedReservationsForSwappedSku($order, $sku, abs($qty), $websiteId);
+        }
+    }
+
+    /**
+     * Create ORDER_PLACED -qty + SHIPMENT_CREATED +qty reservations for a SKU
+     * that was swapped in during a Configure operation on an already-shipped
+     * order item. Net effect on salable qty is zero (the source_item update
+     * above is what actually moves the needle), but the reservation records
+     * give MSI a complete lifecycle to reason about during cancel/void/refund.
+     *
+     * Errors are caught and ignored — failing to create reservations should
+     * not abort the order edit, since the source_item has already been
+     * updated (the user-visible part is correct).
+     */
+    private function placePairedReservationsForSwappedSku(
+        OrderInterface $order,
+        string $sku,
+        float $absQty,
+        int $websiteId
+    ): void {
+        try {
+            $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
+            $salesChannel = $this->salesChannelFactory->create([
+                'data' => [
+                    'type' => SalesChannelInterface::TYPE_WEBSITE,
+                    'code' => $websiteCode,
+                ],
+            ]);
+
+            $extension = $this->salesEventExtensionFactory->create([
+                'data' => [
+                    'objectIncrementId' => (string) $order->getIncrementId(),
+                ],
+            ]);
+
+            // ORDER_PLACED: -qty
+            $orderPlacedEvent = $this->salesEventFactory->create([
+                'type'       => SalesEventInterface::EVENT_ORDER_PLACED,
+                'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
+                'objectId'   => (string) $order->getEntityId(),
+            ]);
+            $orderPlacedEvent->setExtensionAttributes($extension);
+            $this->placeReservationsForSalesEvent->execute(
+                [$this->itemsToSellFactory->create(['sku' => $sku, 'qty' => -$absQty])],
+                $salesChannel,
+                $orderPlacedEvent
+            );
+
+            // SHIPMENT_CREATED: +qty (compensation for the deduct above)
+            $shipmentEvent = $this->salesEventFactory->create([
+                'type'       => 'shipment_created',
+                'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
+                'objectId'   => (string) $order->getEntityId(),
+            ]);
+            $shipmentEvent->setExtensionAttributes($extension);
+            $this->placeReservationsForSalesEvent->execute(
+                [$this->itemsToSellFactory->create(['sku' => $sku, 'qty' => $absQty])],
+                $salesChannel,
+                $shipmentEvent
+            );
+        } catch (\Throwable $e) {
+            // Non-fatal: source_item adjustment above is what users see.
+            // Reservations matter only for downstream cancel/void/refund.
         }
     }
 

--- a/Model/Stock/MultiSourceInventoryManager.php
+++ b/Model/Stock/MultiSourceInventoryManager.php
@@ -60,18 +60,28 @@ class MultiSourceInventoryManager implements StockManagerInterface
     /**
      * Register stock adjustment by product ID.
      *
-     * Directly adjusts source item qty (physical stock).
-     * Salable qty updates automatically: salable = source_qty - sum(reservations).
+     * Two semantically different modes:
      *
-     * Positive qty = return to stock; negative qty = deduct from stock.
-     * Used when replacing a configurable child product during order edit (Configure action).
+     * 1. **Legacy mode** (`$order === null`) — direct source_item adjustment.
+     *    Positive qty = return to stock; negative = deduct. Used when there
+     *    is no order context (rare). Salable updates automatically.
      *
-     * When $order is provided AND $qty is negative (deduct case), also creates
-     * paired reservations for the new SKU mirroring the lifecycle of the
-     * original order item: ORDER_PLACED -|qty| + SHIPMENT_CREATED +|qty|
-     * (net = 0). Without these, downstream operations (cancel shipment, void,
-     * refund) misbehave for the swapped-in SKU because MSI has no record of
-     * the virtual order_placed event for it. See REFACTORING_ROADMAP.md §4.2.3.
+     * 2. **Configure-swap mode** (`$order !== null`) — reservation-only swap
+     *    of the *pending* portion of an order item between the old and new
+     *    child SKU. Caller is responsible for passing only the pending qty
+     *    (qty_ordered − qty_shipped). The shipped portion is already
+     *    physically with the customer under the old SKU and must NOT be
+     *    touched in inventory — touching it creates phantom inflation /
+     *    deflation. See REFACTORING_ROADMAP.md §4.2.6.
+     *
+     *    In this mode `inventory_source_item` is **not** modified — there
+     *    is no physical event yet, only a logical swap of which SKU the
+     *    pending qty is reserved against:
+     *      - Positive qty (release old SKU) → ORDER_CANCELED reservation
+     *        compensating the original order_placed.
+     *      - Negative qty (reserve new SKU) → ORDER_PLACED reservation.
+     *    A real shipment_created reservation will be added later by the
+     *    standard MSI flow when the user creates a shipment for the new SKU.
      */
     public function registerReturnByProductId(
         int $productId,
@@ -85,14 +95,17 @@ class MultiSourceInventoryManager implements StockManagerInterface
             return;
         }
 
+        if ($order !== null) {
+            // Configure-swap mode: reservation-only, no source_item touch.
+            $this->placeConfigureSwapReservation($order, $sku, $qty, $websiteId);
+            return;
+        }
+
+        // Legacy mode: direct source_item adjust.
         $sourceItems = $this->getSourceItemsBySku->execute($sku);
         if (empty($sourceItems)) {
             return;
         }
-
-        // Adjust the first enabled source item.
-        // For multi-source setups the correct approach is to identify the shipment source,
-        // but for order editing single-source is the common case.
         foreach ($sourceItems as $sourceItem) {
             if ((int) $sourceItem->getStatus() !== 1) {
                 continue;
@@ -102,30 +115,27 @@ class MultiSourceInventoryManager implements StockManagerInterface
             $this->sourceItemsSave->execute([$sourceItem]);
             break;
         }
-
-        // Pair reservations for the new SKU on deduct (Configure swap on shipped item).
-        if ($order !== null && $qty < 0) {
-            $this->placePairedReservationsForSwappedSku($order, $sku, abs($qty), $websiteId);
-        }
     }
 
     /**
-     * Create ORDER_PLACED -qty + SHIPMENT_CREATED +qty reservations for a SKU
-     * that was swapped in during a Configure operation on an already-shipped
-     * order item. Net effect on salable qty is zero (the source_item update
-     * above is what actually moves the needle), but the reservation records
-     * give MSI a complete lifecycle to reason about during cancel/void/refund.
+     * Create a single reservation reflecting one side of a Configure swap on
+     * the pending portion of an order item:
+     *  - $qty < 0  → ORDER_PLACED (reserves the new SKU's pending portion)
+     *  - $qty > 0  → ORDER_CANCELED (releases the old SKU's pending portion)
      *
-     * Errors are caught and ignored — failing to create reservations should
-     * not abort the order edit, since the source_item has already been
-     * updated (the user-visible part is correct).
+     * Errors are caught and ignored — Configure swap must not abort over an
+     * MSI hiccup; salable qty drift becomes visible at most for one SKU.
      */
-    private function placePairedReservationsForSwappedSku(
+    private function placeConfigureSwapReservation(
         OrderInterface $order,
         string $sku,
-        float $absQty,
+        float $qty,
         int $websiteId
     ): void {
+        if (abs($qty) < 0.00001) {
+            return;
+        }
+
         try {
             $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
             $salesChannel = $this->salesChannelFactory->create([
@@ -141,34 +151,27 @@ class MultiSourceInventoryManager implements StockManagerInterface
                 ],
             ]);
 
-            // ORDER_PLACED: -qty
-            $orderPlacedEvent = $this->salesEventFactory->create([
-                'type'       => SalesEventInterface::EVENT_ORDER_PLACED,
-                'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
-                'objectId'   => (string) $order->getEntityId(),
-            ]);
-            $orderPlacedEvent->setExtensionAttributes($extension);
-            $this->placeReservationsForSalesEvent->execute(
-                [$this->itemsToSellFactory->create(['sku' => $sku, 'qty' => -$absQty])],
-                $salesChannel,
-                $orderPlacedEvent
-            );
+            // Negative qty = reserve new SKU under ORDER_PLACED.
+            // Positive qty = release old SKU under ORDER_CANCELED.
+            $eventType = $qty < 0
+                ? SalesEventInterface::EVENT_ORDER_PLACED
+                : 'order_canceled';
 
-            // SHIPMENT_CREATED: +qty (compensation for the deduct above)
-            $shipmentEvent = $this->salesEventFactory->create([
-                'type'       => 'shipment_created',
+            $salesEvent = $this->salesEventFactory->create([
+                'type'       => $eventType,
                 'objectType' => SalesEventInterface::OBJECT_TYPE_ORDER,
                 'objectId'   => (string) $order->getEntityId(),
             ]);
-            $shipmentEvent->setExtensionAttributes($extension);
+            $salesEvent->setExtensionAttributes($extension);
+
             $this->placeReservationsForSalesEvent->execute(
-                [$this->itemsToSellFactory->create(['sku' => $sku, 'qty' => $absQty])],
+                [$this->itemsToSellFactory->create(['sku' => $sku, 'qty' => $qty])],
                 $salesChannel,
-                $shipmentEvent
+                $salesEvent
             );
         } catch (\Throwable $e) {
-            // Non-fatal: source_item adjustment above is what users see.
-            // Reservations matter only for downstream cancel/void/refund.
+            // Non-fatal: Configure swap proceeds; missing reservation may show
+            // as small salable drift on this SKU only. Logged elsewhere by stock service.
         }
     }
 

--- a/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
+++ b/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
@@ -142,7 +142,7 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
     /**
      * @inheritDoc
      */
-    public function execute(ShipmentInterface $shipment): void
+    public function execute(ShipmentInterface $shipment, array &$remainingByOrderItem = []): void
     {
         $this->stockDebugLogger->open('CancelShipmentProcessor::execute', [
             'shipment_id' => (int)$shipment->getEntityId(),
@@ -183,22 +183,34 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
                 continue;
             }
 
-            $orderItem = $this->orderItemRepository->get((int)$shipmentItem->getOrderItemId());
+            $orderItemId = (int)$shipmentItem->getOrderItemId();
+            $orderItem   = $this->orderItemRepository->get($orderItemId);
 
-            // Return only the still-shippable qty — the amount the recreated
-            // shipment will re-deduct — so the delete+recreate pair is stock-neutral.
-            // The refunded/canceled portions are returned by the credit memo / cancel
-            // flow, which stay their sole owners (avoids double return).
+            // Return only the still-shippable qty — the amount the recreated shipment
+            // will re-deduct — so the delete+recreate pair is stock-neutral; the
+            // refunded/canceled portions are returned by the credit memo / cancel flow
+            // (their sole owners), which avoids a double return.
             //
-            // Using the old shipment qty (or shipmentQty − refunded with the CUMULATIVE
-            // refunded) breaks on a SECOND edit: the old shipment qty is already reduced
-            // and qty_refunded is cumulative, so the math drifts. qtyToShip is derived
-            // from the order item and is correct across any number of sequential edits.
-            // Capped at the shipment qty (can't return more than this shipment moved).
-            $qtyToShip = (float)$orderItem->getQtyOrdered()
-                - (float)$orderItem->getQtyRefunded()
-                - (float)$orderItem->getQtyCanceled();
+            // qtyToShip is the TOTAL still-shippable qty for the order item and acts as
+            // a budget SHARED across every shipment of this order cancelled in one pass.
+            // An "Add new shipment" edit leaves several shipments (e.g. 5 + 3); without
+            // the shared budget each would return min(qtyToShip, shipmentQty) and the
+            // sum would exceed qtyToShip (over-return). The budget is initialized lazily
+            // per order item and decremented as each shipment returns its share, so the
+            // total returned equals qtyToShip regardless of how the qty is split.
+            // It is also derived from the order item (not the old shipment qty), so it
+            // stays correct across any number of sequential edits.
+            if (!array_key_exists($orderItemId, $remainingByOrderItem)) {
+                $remainingByOrderItem[$orderItemId] = max(
+                    (float)$orderItem->getQtyOrdered()
+                    - (float)$orderItem->getQtyRefunded()
+                    - (float)$orderItem->getQtyCanceled(),
+                    0.0
+                );
+            }
+            $qtyToShip = $remainingByOrderItem[$orderItemId];
             $backQty   = max(min($qtyToShip, (float)$shipmentItem->getQty()), 0.0);
+            $remainingByOrderItem[$orderItemId] = $qtyToShip - $backQty;
             $sku       = $shipmentItem->getSku();
 
             $sourceItem = $this->getSourceItemBySourceCodeAndSku->execute($sourceCode, $sku);
@@ -213,7 +225,8 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
                 'qty_ordered'      => (float)$orderItem->getQtyOrdered(),
                 'qty_refunded'     => (float)$orderItem->getQtyRefunded(),
                 'qty_canceled'     => (float)$orderItem->getQtyCanceled(),
-                'qty_to_ship'      => $qtyToShip,
+                'budget_used'      => $qtyToShip,
+                'budget_left'      => $remainingByOrderItem[$orderItemId],
                 'back_qty'         => (float)$backQty,
                 'source_before'    => $qtyBefore,
                 'source_after'     => $qtyBefore + $backQty,

--- a/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
+++ b/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
@@ -29,6 +29,7 @@ use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
 use Magento\Store\Api\WebsiteRepositoryInterface;
+use MageWorx\OrderEditor\Model\Order\Item\Quantity\ItemQuantitiesResolver;
 use MageWorx\OrderEditor\Model\StockDebugLogger;
 use MageWorx\OrderEditorInventory\Api\CancelShipmentProcessorInterface;
 use Psr\Log\LoggerInterface;
@@ -96,6 +97,11 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
     private $stockDebugLogger;
 
     /**
+     * @var ItemQuantitiesResolver
+     */
+    private ItemQuantitiesResolver $itemQuantitiesResolver;
+
+    /**
      * CancelShipmentProcessor constructor.
      *
      * @param SalesEventInterfaceFactory $salesEventFactory
@@ -110,6 +116,7 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
      * @param WebsiteRepositoryInterface $websiteRepository
      * @param LoggerInterface $logger
      * @param StockDebugLogger $stockDebugLogger
+     * @param ItemQuantitiesResolver $itemQuantitiesResolver
      */
     public function __construct(
         SalesEventInterfaceFactory              $salesEventFactory,
@@ -123,7 +130,8 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
         SalesChannelInterfaceFactory            $salesChannelFactory,
         WebsiteRepositoryInterface              $websiteRepository,
         LoggerInterface                         $logger,
-        StockDebugLogger                        $stockDebugLogger
+        StockDebugLogger                        $stockDebugLogger,
+        ItemQuantitiesResolver                  $itemQuantitiesResolver
     ) {
         $this->salesEventFactory               = $salesEventFactory;
         $this->itemsToSellFactory              = $itemsToSellFactory;
@@ -137,6 +145,7 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
         $this->websiteRepository               = $websiteRepository;
         $this->logger                          = $logger;
         $this->stockDebugLogger                = $stockDebugLogger;
+        $this->itemQuantitiesResolver          = $itemQuantitiesResolver;
     }
 
     /**
@@ -202,9 +211,7 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
             // stays correct across any number of sequential edits.
             if (!array_key_exists($orderItemId, $remainingByOrderItem)) {
                 $remainingByOrderItem[$orderItemId] = max(
-                    (float)$orderItem->getQtyOrdered()
-                    - (float)$orderItem->getQtyRefunded()
-                    - (float)$orderItem->getQtyCanceled(),
+                    $this->itemQuantitiesResolver->resolve($orderItem)->kept(),
                     0.0
                 );
             }

--- a/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
+++ b/Model/Stock/ReturnProcessor/CancelShipmentProcessor.php
@@ -29,6 +29,7 @@ use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
 use Magento\Store\Api\WebsiteRepositoryInterface;
+use MageWorx\OrderEditor\Model\StockDebugLogger;
 use MageWorx\OrderEditorInventory\Api\CancelShipmentProcessorInterface;
 use Psr\Log\LoggerInterface;
 
@@ -90,6 +91,11 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
     private $websiteRepository;
 
     /**
+     * @var StockDebugLogger
+     */
+    private $stockDebugLogger;
+
+    /**
      * CancelShipmentProcessor constructor.
      *
      * @param SalesEventInterfaceFactory $salesEventFactory
@@ -100,7 +106,10 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
      * @param OrderRepositoryInterface $orderRepository
      * @param SourceItemsSaveInterface $sourceItemsSave
      * @param GetSourceItemBySourceCodeAndSku $getSourceItemBySourceCodeAndSku
+     * @param SalesChannelInterfaceFactory $salesChannelFactory
+     * @param WebsiteRepositoryInterface $websiteRepository
      * @param LoggerInterface $logger
+     * @param StockDebugLogger $stockDebugLogger
      */
     public function __construct(
         SalesEventInterfaceFactory              $salesEventFactory,
@@ -113,7 +122,8 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
         GetSourceItemBySourceCodeAndSku         $getSourceItemBySourceCodeAndSku,
         SalesChannelInterfaceFactory            $salesChannelFactory,
         WebsiteRepositoryInterface              $websiteRepository,
-        LoggerInterface                         $logger
+        LoggerInterface                         $logger,
+        StockDebugLogger                        $stockDebugLogger
     ) {
         $this->salesEventFactory               = $salesEventFactory;
         $this->itemsToSellFactory              = $itemsToSellFactory;
@@ -126,6 +136,7 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
         $this->salesChannelFactory             = $salesChannelFactory;
         $this->websiteRepository               = $websiteRepository;
         $this->logger                          = $logger;
+        $this->stockDebugLogger                = $stockDebugLogger;
     }
 
     /**
@@ -133,12 +144,23 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
      */
     public function execute(ShipmentInterface $shipment): void
     {
+        $this->stockDebugLogger->open('CancelShipmentProcessor::execute', [
+            'shipment_id' => (int)$shipment->getEntityId(),
+            'order_id'    => (int)$shipment->getOrderId(),
+            'source_code' => $shipment->getExtensionAttributes()
+                ? $shipment->getExtensionAttributes()->getSourceCode()
+                : null,
+        ]);
+
         $shipmentItems = $shipment->getAllItems();
         if (empty($shipmentItems)) {
+            $this->stockDebugLogger->warn('no shipment items — nothing to return');
+            $this->stockDebugLogger->close('skipped');
             return;
         }
 
-        $itemToSell = [];
+        $itemToSell  = [];
+        $sourceItems = [];
 
         /** @var ShipmentItem $shipmentItem */
         foreach ($shipmentItems as $shipmentItem) {
@@ -147,30 +169,56 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
              * @var ShipmentExtension|null $extensionAttributes
              */
             $extensionAttributes = $shipment->getExtensionAttributes();
-            if (!is_null($extensionAttributes)) {
+            if ($extensionAttributes !== null) {
                 $sourceCode = $extensionAttributes->getSourceCode();
             }
             if ($sourceCode === null) {
-                continue; // Source code is not set, we can't return items
+                // Source code is not set, we can't return items. Silent skip here
+                // means deleted-shipment stock is never given back — log it loudly.
+                $this->stockDebugLogger->warn('source_code is null — stock NOT returned for item', [
+                    'order_item_id' => (int)$shipmentItem->getOrderItemId(),
+                    'sku'           => $shipmentItem->getSku(),
+                    'qty'           => (float)$shipmentItem->getQty(),
+                ]);
+                continue;
             }
 
             $orderItem = $this->orderItemRepository->get((int)$shipmentItem->getOrderItemId());
-            if ($orderItem->getQtyShipped() > $orderItem->getQtyOrdered()) {
-                /**
-                 * Negative modification which will prevent double deduction
-                 * because we already removed item from stock in
-                 * \MageWorx\OrderEditorInventory\Model\StockQtyManager::returnQtyToStock() method
-                 */
-                $qtyModification = $orderItem->getQtyOrdered() - $orderItem->getQtyShipped();
-            } else {
-                $qtyModification = 0;
-            }
-            $backQty = $shipmentItem->getQty() + $qtyModification;
-            $sku     = $shipmentItem->getSku();
+
+            // Return only the still-shippable qty — the amount the recreated
+            // shipment will re-deduct — so the delete+recreate pair is stock-neutral.
+            // The refunded/canceled portions are returned by the credit memo / cancel
+            // flow, which stay their sole owners (avoids double return).
+            //
+            // Using the old shipment qty (or shipmentQty − refunded with the CUMULATIVE
+            // refunded) breaks on a SECOND edit: the old shipment qty is already reduced
+            // and qty_refunded is cumulative, so the math drifts. qtyToShip is derived
+            // from the order item and is correct across any number of sequential edits.
+            // Capped at the shipment qty (can't return more than this shipment moved).
+            $qtyToShip = (float)$orderItem->getQtyOrdered()
+                - (float)$orderItem->getQtyRefunded()
+                - (float)$orderItem->getQtyCanceled();
+            $backQty   = max(min($qtyToShip, (float)$shipmentItem->getQty()), 0.0);
+            $sku       = $shipmentItem->getSku();
 
             $sourceItem = $this->getSourceItemBySourceCodeAndSku->execute($sourceCode, $sku);
+            $qtyBefore  = (float)$sourceItem->getQuantity();
             $sourceItem->setQuantity($sourceItem->getQuantity() + $backQty);
             $sourceItems[] = $sourceItem;
+
+            $this->stockDebugLogger->log('return shipment qty to source', [
+                'sku'              => $sku,
+                'source_code'      => $sourceCode,
+                'shipment_qty'     => (float)$shipmentItem->getQty(),
+                'qty_ordered'      => (float)$orderItem->getQtyOrdered(),
+                'qty_refunded'     => (float)$orderItem->getQtyRefunded(),
+                'qty_canceled'     => (float)$orderItem->getQtyCanceled(),
+                'qty_to_ship'      => $qtyToShip,
+                'back_qty'         => (float)$backQty,
+                'source_before'    => $qtyBefore,
+                'source_after'     => $qtyBefore + $backQty,
+                'reservation_comp' => (float)-$backQty,
+            ]);
 
             // Reservation compensation should be negative!
             $itemToSell[] = $this->itemsToSellFactory->create(
@@ -187,14 +235,23 @@ class CancelShipmentProcessor implements CancelShipmentProcessorInterface
                 try {
                     $this->placeReservationForCancelShipmentEvent($shipment, $itemToSell);
                 } catch (LocalizedException $localizedException) {
+                    $this->stockDebugLogger->warn('reservation compensation failed', [
+                        'error' => $localizedException->getLogMessage(),
+                    ]);
                     $this->logger->error($localizedException->getLogMessage());
                 }
             } catch (CouldNotSaveException $e) {
+                $this->stockDebugLogger->warn('source items save failed', ['error' => $e->getLogMessage()]);
                 $this->logger->error($e->getLogMessage());
             } catch (InputException|ValidationException $e) {
+                $this->stockDebugLogger->warn('source items save invalid', ['error' => $e->getLogMessage()]);
                 $this->logger->notice($e->getLogMessage());
             }
+        } else {
+            $this->stockDebugLogger->warn('no source items collected — no stock returned for this shipment');
         }
+
+        $this->stockDebugLogger->close('cancel shipment done');
     }
 
     /**

--- a/Model/Stock/SourceCodeResolver.php
+++ b/Model/Stock/SourceCodeResolver.php
@@ -1,0 +1,207 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Model\Stock;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceRepositoryInterface;
+use Magento\InventoryApi\Api\GetSourcesAssignedToStockOrderedByPriorityInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Store\Model\ScopeInterface;
+
+/**
+ * Resolves the source_code to deduct/return qty from for a given SKU during
+ * a swap physical exchange.
+ *
+ * Three-tier strategy (per spec):
+ *   1. shipment_source — if the original shipment record points at a source
+ *      where the SKU has sufficient qty (or backorders are explicitly OK),
+ *      use it. Returning old SKU here is straightforward (we add qty), and
+ *      deducting new SKU from the same source preserves "where the package
+ *      came from" intuition.
+ *   2. priority-ordered sources of the website's stock — first source with
+ *      sufficient qty / backorder permission.
+ *   3. null — caller must throw.
+ *
+ * Returns null instead of throwing so the caller can compose a precise
+ * error message ("New SKU 'cfg-1-XL' is not available on any source...").
+ */
+class SourceCodeResolver
+{
+    public function __construct(
+        private GetSourceItemsBySkuInterface $getSourceItemsBySku,
+        private GetSourcesAssignedToStockOrderedByPriorityInterface $getSourcesByStock,
+        private StockResolverInterface $stockResolver,
+        private WebsiteRepositoryInterface $websiteRepository,
+        private SourceRepositoryInterface $sourceRepository,
+        private ResourceConnection $resourceConnection,
+        private BackorderPolicy $backorderPolicy
+    ) {
+    }
+
+    /**
+     * Read shipment_source codes for a given order item from
+     * `inventory_shipment_source` (set by Magento's shipment service when a
+     * shipment is created). Handles split shipments — returns multiple codes
+     * with their respective qty contribution.
+     *
+     * @return array<string, float> [source_code => qty_shipped_from_this_source]
+     */
+    public function resolveShipmentSources(int $orderItemId): array
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $shipmentItemTable = $this->resourceConnection->getTableName('sales_shipment_item');
+        $shipmentSourceTable = $this->resourceConnection->getTableName('inventory_shipment_source');
+
+        // Join shipment_item → shipment → inventory_shipment_source by shipment increment_id.
+        // The Magento extension attribute is keyed by shipment, not by item, so all
+        // items in the same shipment share the same source.
+        $select = $connection->select()
+            ->from(['si' => $shipmentItemTable], ['qty'])
+            ->joinInner(
+                ['s' => $this->resourceConnection->getTableName('sales_shipment')],
+                's.entity_id = si.parent_id',
+                []
+            )
+            ->joinInner(
+                ['iss' => $shipmentSourceTable],
+                'iss.shipment_id = s.increment_id',
+                ['source_code']
+            )
+            ->where('si.order_item_id = ?', $orderItemId);
+
+        $sources = [];
+        foreach ($connection->fetchAll($select) as $row) {
+            $code = (string) $row['source_code'];
+            $sources[$code] = ($sources[$code] ?? 0.0) + (float) $row['qty'];
+        }
+
+        return $sources;
+    }
+
+    /**
+     * Find a source code suitable for deducting `qtyNeeded` of `$sku`.
+     * Tries `$preferredSourceCode` first if non-null, then iterates the
+     * priority list of sources assigned to the website's stock.
+     *
+     * Returns null if no source qualifies (caller throws with details).
+     */
+    public function findDeductionSource(
+        string $sku,
+        int $websiteId,
+        float $qtyNeeded,
+        ?string $preferredSourceCode = null
+    ): ?string {
+        $backorderAllowed = $this->backorderPolicy->isBackorderAllowed($sku, $websiteId);
+        $availabilityBySource = $this->getAvailabilityBySource($sku);
+
+        // Tier 1: preferred (e.g. shipment) source — if SKU is assigned, active,
+        // and has either enough qty or backorders enabled.
+        if ($preferredSourceCode !== null
+            && $this->isSourceUsable(
+                $availabilityBySource,
+                $preferredSourceCode,
+                $qtyNeeded,
+                $backorderAllowed
+            )
+        ) {
+            return $preferredSourceCode;
+        }
+
+        // Tier 2: priority-ordered sources of the stock assigned to this website.
+        try {
+            $websiteCode = $this->websiteRepository->getById($websiteId)->getCode();
+            $stock = $this->stockResolver->execute(ScopeInterface::SCOPE_WEBSITE, $websiteCode);
+            $stockId = (int) $stock->getStockId();
+            $sources = $this->getSourcesByStock->execute($stockId);
+            foreach ($sources as $source) {
+                if (!$source->isEnabled()) {
+                    continue;
+                }
+                $code = $source->getSourceCode();
+                if ($code === $preferredSourceCode) {
+                    continue; // already tried
+                }
+                if ($this->isSourceUsable(
+                    $availabilityBySource,
+                    $code,
+                    $qtyNeeded,
+                    $backorderAllowed
+                )) {
+                    return $code;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Stock not resolvable — fall through to null.
+        }
+
+        return null;
+    }
+
+    /**
+     * Return source code for adding qty back of `$sku` (return-to-stock
+     * direction). Always succeeds for a source where SKU is assigned and
+     * enabled — we never need backorder check on the return side. Falls
+     * back to first eligible source, or null if SKU is assigned nowhere.
+     */
+    public function findReturnSource(string $sku, int $websiteId, ?string $preferredSourceCode = null): ?string
+    {
+        $availability = $this->getAvailabilityBySource($sku);
+        if ($preferredSourceCode !== null && isset($availability[$preferredSourceCode])) {
+            return $preferredSourceCode;
+        }
+        // Any assigned-and-enabled source will accept a +qty.
+        foreach ($availability as $code => $info) {
+            if ($info['status'] === SourceItemInterface::STATUS_IN_STOCK || $info['source_enabled']) {
+                return (string) $code;
+            }
+        }
+        return array_key_first($availability) !== null ? (string) array_key_first($availability) : null;
+    }
+
+    /**
+     * @return array<string, array{quantity: float, status: int, source_enabled: bool}>
+     */
+    private function getAvailabilityBySource(string $sku): array
+    {
+        $result = [];
+        foreach ($this->getSourceItemsBySku->execute($sku) as $sourceItem) {
+            $code = $sourceItem->getSourceCode();
+            $sourceEnabled = false;
+            try {
+                $sourceEnabled = $this->sourceRepository->get($code)->isEnabled();
+            } catch (\Throwable $e) {
+                // unknown source — treat as disabled
+            }
+            $result[$code] = [
+                'quantity' => (float) $sourceItem->getQuantity(),
+                'status' => (int) $sourceItem->getStatus(),
+                'source_enabled' => $sourceEnabled,
+            ];
+        }
+        return $result;
+    }
+
+    private function isSourceUsable(
+        array $availabilityBySource,
+        string $sourceCode,
+        float $qtyNeeded,
+        bool $backorderAllowed
+    ): bool {
+        if (!isset($availabilityBySource[$sourceCode])) {
+            return false;
+        }
+        $info = $availabilityBySource[$sourceCode];
+        if (!$info['source_enabled']) {
+            return false;
+        }
+        if ($info['quantity'] >= $qtyNeeded) {
+            return true;
+        }
+        return $backorderAllowed;
+    }
+}

--- a/Model/StockQtyManager.php
+++ b/Model/StockQtyManager.php
@@ -368,8 +368,8 @@ class StockQtyManager implements StockQtyManagerInterface
     /**
      * @param ShipmentInterface $shipment
      */
-    public function cancelShipment(ShipmentInterface $shipment): void
+    public function cancelShipment(ShipmentInterface $shipment, array &$remainingByOrderItem = []): void
     {
-        $this->processCancelledShipmentItems->execute($shipment);
+        $this->processCancelledShipmentItems->execute($shipment, $remainingByOrderItem);
     }
 }

--- a/Model/StockQtyManager.php
+++ b/Model/StockQtyManager.php
@@ -338,11 +338,17 @@ class StockQtyManager implements StockQtyManagerInterface
 
                 $qtyToReturn = abs($qty); // Qty to return
                 /**
-                 * Total items with currently returning qty
-                 * Overall qty without refunded before items
+                 * processedQty feeds the native Magento\InventorySalesApi
+                 * ProcessRefundItems consumer, which expects the same value the
+                 * native ProcessReturnQtyOnCreditMemoPlugin produces:
+                 *   qtyInvoiced - qtyRefunded + (currently returning qty).
+                 * The previous formula (qtyOrdered - qtyCanceled - qtyRefunded)
+                 * ignored qtyInvoiced and the current qty, so the source-vs-stock
+                 * split in ProcessRefundItems was wrong on partial-invoice orders.
                  */
-                $processedQty = /* @TODO: Qty ordered should be here? */
-                    $orderItem->getQtyOrdered() - $orderItem->getQtyCanceled() - $orderItem->getQtyRefunded(); // All qty before return
+                $processedQty = (float) $orderItem->getQtyInvoiced()
+                    - (float) $orderItem->getQtyRefunded()
+                    + $qtyToReturn;
 
                 $itemsToRefund[] = $this->itemsToRefundFactory->create(
                     [

--- a/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
+++ b/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
@@ -6,9 +6,17 @@
 
 namespace MageWorx\OrderEditorInventory\Test\Unit\Model\CancelShipmentProcessor;
 
+use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\Inventory\Model\SourceItem;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventorySourceDeductionApi\Model\GetSourceItemBySourceCodeAndSku;
+use Magento\Sales\Api\Data\ShipmentExtensionInterface;
+use Magento\Sales\Api\OrderItemRepositoryInterface;
+use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Sales\Model\Order\Shipment;
+use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
 use MageWorx\OrderEditorInventory\Model\Stock\ReturnProcessor\CancelShipmentProcessor;
 use PHPUnit\Framework\TestCase;
 
@@ -57,5 +65,103 @@ class CancelShipmentTest extends TestCase
                  ->willReturn([]);
 
         $this->cancelShipmentProcessor->execute($shipment);
+    }
+
+    /**
+     * Refunded qty is returned to stock by the credit memo flow, so cancelShipment
+     * must exclude it: shipped 5, refunded 1 → return only 4 to source.
+     */
+    public function testExcludesRefundedQtyFromStockReturn(): void
+    {
+        $this->assertBackToSource(shipmentQty: 5.0, qtyShipped: 5.0, qtyOrdered: 5.0, qtyRefunded: 1.0, expectedBack: 4.0);
+    }
+
+    /**
+     * Nothing refunded → full shipped qty returns to source.
+     */
+    public function testReturnsFullQtyWhenNothingRefunded(): void
+    {
+        $this->assertBackToSource(shipmentQty: 5.0, qtyShipped: 5.0, qtyOrdered: 5.0, qtyRefunded: 0.0, expectedBack: 5.0);
+    }
+
+    /**
+     * Fully refunded (item removed) → credit memo owns the whole return, cancel returns 0.
+     */
+    public function testReturnsZeroWhenFullyRefunded(): void
+    {
+        $this->assertBackToSource(shipmentQty: 5.0, qtyShipped: 5.0, qtyOrdered: 5.0, qtyRefunded: 5.0, expectedBack: 0.0);
+    }
+
+    /**
+     * Second sequential edit: the recreated shipment from edit #1 is 4, but only 2
+     * remain shippable (ordered 5, cumulative refunded 3). Must return the shippable
+     * qty 2 — not the old shipment qty 4, nor shipmentQty−cumulativeRefunded (4−3=1).
+     */
+    public function testUsesShippableQtyOnSecondEdit(): void
+    {
+        $this->assertBackToSource(shipmentQty: 4.0, qtyShipped: 4.0, qtyOrdered: 5.0, qtyRefunded: 3.0, expectedBack: 2.0);
+    }
+
+    /**
+     * Build the processor with controlled collaborators, run execute() and assert the
+     * source quantity was bumped by exactly $expectedBack (qtyBefore + expectedBack).
+     * sourceItemsSave is made to throw so the reservation path is skipped — the
+     * physical return (setQuantity) already happened in the loop before the save.
+     */
+    private function assertBackToSource(
+        float $shipmentQty,
+        float $qtyShipped,
+        float $qtyOrdered,
+        float $qtyRefunded,
+        float $expectedBack
+    ): void {
+        $qtyBefore = 96.0;
+        $sku       = 'WH12-XL-Purple';
+
+        $ext = $this->createMock(ShipmentExtensionInterface::class);
+        $ext->method('getSourceCode')->willReturn('default');
+
+        $shipmentItem = $this->createMock(ShipmentItem::class);
+        $shipmentItem->method('getOrderItemId')->willReturn(612);
+        $shipmentItem->method('getSku')->willReturn($sku);
+        $shipmentItem->method('getQty')->willReturn($shipmentQty);
+
+        $shipment = $this->createMock(Shipment::class);
+        $shipment->method('getAllItems')->willReturn([$shipmentItem]);
+        $shipment->method('getExtensionAttributes')->willReturn($ext);
+        $shipment->method('getOrderId')->willReturn(251);
+        $shipment->method('getEntityId')->willReturn(80);
+
+        $orderItem = $this->createMock(OrderItem::class);
+        $orderItem->method('getQtyShipped')->willReturn($qtyShipped);
+        $orderItem->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $orderItem->method('getQtyRefunded')->willReturn($qtyRefunded);
+
+        $orderItemRepository = $this->createMock(OrderItemRepositoryInterface::class);
+        $orderItemRepository->method('get')->with(612)->willReturn($orderItem);
+
+        $sourceItem = $this->createMock(SourceItem::class);
+        $sourceItem->method('getQuantity')->willReturn($qtyBefore);
+        $sourceItem->expects($this->once())
+            ->method('setQuantity')
+            ->with($qtyBefore + $expectedBack);
+
+        $getSourceItem = $this->createMock(GetSourceItemBySourceCodeAndSku::class);
+        $getSourceItem->method('execute')->with('default', $sku)->willReturn($sourceItem);
+
+        // Throw so execute() stops before the reservation path (keeps the test focused).
+        $sourceItemsSave = $this->createMock(SourceItemsSaveInterface::class);
+        $sourceItemsSave->method('execute')->willThrowException(new CouldNotSaveException(__('stop')));
+
+        $processor = $this->objectManagerHelper->getObject(
+            CancelShipmentProcessor::class,
+            [
+                'orderItemRepository'             => $orderItemRepository,
+                'getSourceItemBySourceCodeAndSku' => $getSourceItem,
+                'sourceItemsSave'                 => $sourceItemsSave,
+            ]
+        );
+
+        $processor->execute($shipment);
     }
 }

--- a/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
+++ b/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
@@ -103,6 +103,76 @@ class CancelShipmentTest extends TestCase
     }
 
     /**
+     * Add-new-shipment leaves several shipments (5 + 3). When all are cancelled in one
+     * pass the SHARED budget (qtyToShip = ordered 8 − refunded 2 = 6) must be split,
+     * not applied in full to each: shipment(5) returns 5, shipment(3) returns 1 → total 6,
+     * not 5 + 3 = 8 (which over-returns and inflates source).
+     */
+    public function testDistributesBudgetAcrossMultipleShipments(): void
+    {
+        $sku       = 'WH12-XL-Gray';
+        $qtyBefore = 96.0;
+
+        $orderItem = $this->createMock(OrderItem::class);
+        $orderItem->method('getQtyOrdered')->willReturn(8.0);
+        $orderItem->method('getQtyRefunded')->willReturn(2.0);
+        $orderItem->method('getQtyCanceled')->willReturn(0.0);
+
+        $orderItemRepository = $this->createMock(OrderItemRepositoryInterface::class);
+        $orderItemRepository->method('get')->with(618)->willReturn($orderItem);
+
+        // First shipment returns 5 (budget 6 → 1), second returns 1 (budget 1 → 0).
+        $source1 = $this->createMock(SourceItem::class);
+        $source1->method('getQuantity')->willReturn($qtyBefore);
+        $source1->expects($this->once())->method('setQuantity')->with($qtyBefore + 5.0);
+
+        $source2 = $this->createMock(SourceItem::class);
+        $source2->method('getQuantity')->willReturn($qtyBefore);
+        $source2->expects($this->once())->method('setQuantity')->with($qtyBefore + 1.0);
+
+        $getSourceItem = $this->createMock(GetSourceItemBySourceCodeAndSku::class);
+        $getSourceItem->method('execute')->with('default', $sku)
+            ->willReturnOnConsecutiveCalls($source1, $source2);
+
+        $sourceItemsSave = $this->createMock(SourceItemsSaveInterface::class);
+        $sourceItemsSave->method('execute')->willThrowException(new CouldNotSaveException(__('stop')));
+
+        $processor = $this->objectManagerHelper->getObject(
+            CancelShipmentProcessor::class,
+            [
+                'orderItemRepository'             => $orderItemRepository,
+                'getSourceItemBySourceCodeAndSku' => $getSourceItem,
+                'sourceItemsSave'                 => $sourceItemsSave,
+            ]
+        );
+
+        $budget = [];
+        $processor->execute($this->shipmentWithItem($sku, 5.0), $budget);
+        $processor->execute($this->shipmentWithItem($sku, 3.0), $budget);
+
+        self::assertSame(0.0, $budget[618], 'budget fully consumed across both shipments');
+    }
+
+    private function shipmentWithItem(string $sku, float $qty): Shipment
+    {
+        $ext = $this->createMock(ShipmentExtensionInterface::class);
+        $ext->method('getSourceCode')->willReturn('default');
+
+        $item = $this->createMock(ShipmentItem::class);
+        $item->method('getOrderItemId')->willReturn(618);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQty')->willReturn($qty);
+
+        $shipment = $this->createMock(Shipment::class);
+        $shipment->method('getAllItems')->willReturn([$item]);
+        $shipment->method('getExtensionAttributes')->willReturn($ext);
+        $shipment->method('getOrderId')->willReturn(254);
+        $shipment->method('getEntityId')->willReturn(90);
+
+        return $shipment;
+    }
+
+    /**
      * Build the processor with controlled collaborators, run execute() and assert the
      * source quantity was bumped by exactly $expectedBack (qtyBefore + expectedBack).
      * sourceItemsSave is made to throw so the reservation path is skipped — the

--- a/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
+++ b/Test/Unit/Model/CancelShipmentProcessor/CancelShipmentTest.php
@@ -17,6 +17,7 @@ use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Model\Order\Item as OrderItem;
 use Magento\Sales\Model\Order\Shipment;
 use Magento\Sales\Model\Order\Shipment\Item as ShipmentItem;
+use MageWorx\OrderEditor\Model\Order\Item\Quantity\ItemQuantitiesResolver;
 use MageWorx\OrderEditorInventory\Model\Stock\ReturnProcessor\CancelShipmentProcessor;
 use PHPUnit\Framework\TestCase;
 
@@ -143,6 +144,7 @@ class CancelShipmentTest extends TestCase
                 'orderItemRepository'             => $orderItemRepository,
                 'getSourceItemBySourceCodeAndSku' => $getSourceItem,
                 'sourceItemsSave'                 => $sourceItemsSave,
+                'itemQuantitiesResolver'          => new ItemQuantitiesResolver(),
             ]
         );
 
@@ -229,6 +231,7 @@ class CancelShipmentTest extends TestCase
                 'orderItemRepository'             => $orderItemRepository,
                 'getSourceItemBySourceCodeAndSku' => $getSourceItem,
                 'sourceItemsSave'                 => $sourceItemsSave,
+                'itemQuantitiesResolver'          => new ItemQuantitiesResolver(),
             ]
         );
 

--- a/Test/Unit/Model/CheckItemsQuantityTest.php
+++ b/Test/Unit/Model/CheckItemsQuantityTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model;
+
+use Magento\Framework\Exception\BulkException;
+use Magento\InventorySalesApi\Api\Data\ProductSalabilityErrorInterface;
+use Magento\InventorySalesApi\Api\Data\ProductSalableResultInterface;
+use Magento\InventorySalesApi\Api\IsProductSalableForRequestedQtyInterface;
+use MageWorx\OrderEditorInventory\Model\CheckItemsQuantity;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CheckItemsQuantityTest extends TestCase
+{
+    /**
+     * @var IsProductSalableForRequestedQtyInterface|MockObject
+     */
+    private $isProductSalableForRequestedQty;
+
+    /**
+     * @var CheckItemsQuantity
+     */
+    private CheckItemsQuantity $checkItemsQuantity;
+
+    protected function setUp(): void
+    {
+        $this->isProductSalableForRequestedQty = $this->createMock(IsProductSalableForRequestedQtyInterface::class);
+        $this->checkItemsQuantity              = new CheckItemsQuantity(
+            $this->isProductSalableForRequestedQty
+        );
+    }
+
+    public function testEmptyItemsReturnsWithoutCallingService(): void
+    {
+        $this->isProductSalableForRequestedQty->expects($this->never())->method('execute');
+
+        $this->checkItemsQuantity->execute([], 1);
+    }
+
+    public function testAllItemsSalableNoException(): void
+    {
+        $items = [
+            'sku-1' => 1.0,
+            'sku-2' => 2.5,
+        ];
+
+        $salable = $this->createSalableResult(true);
+        $this->isProductSalableForRequestedQty->expects($this->exactly(2))
+                                              ->method('execute')
+                                              ->willReturn($salable);
+
+        $this->checkItemsQuantity->execute($items, 1);
+    }
+
+    public function testPartialFailuresAggregatedAsBulkException(): void
+    {
+        $items = [
+            'sku-good' => 1.0,
+            'sku-bad'  => 5.0,
+        ];
+
+        $okResult   = $this->createSalableResult(true);
+        $failResult = $this->createSalableResult(false, 'Out of stock');
+
+        $this->isProductSalableForRequestedQty->method('execute')
+                                              ->willReturnCallback(
+                                                  function (string $sku) use ($okResult, $failResult) {
+                                                      return $sku === 'sku-good' ? $okResult : $failResult;
+                                                  }
+                                              );
+
+        $this->expectException(BulkException::class);
+        $this->checkItemsQuantity->execute($items, 1);
+    }
+
+    public function testAllItemsFailingThrowsBulkExceptionWithAllErrors(): void
+    {
+        $items = [
+            'sku-1' => 1.0,
+            'sku-2' => 2.0,
+        ];
+
+        $failResult = $this->createSalableResult(false, 'Not enough qty');
+        $this->isProductSalableForRequestedQty->method('execute')->willReturn($failResult);
+
+        try {
+            $this->checkItemsQuantity->execute($items, 1);
+            $this->fail('BulkException expected');
+        } catch (BulkException $e) {
+            $this->assertCount(2, $e->getErrors());
+        }
+    }
+
+    /**
+     * @param bool $salable
+     * @param string $errorMessage
+     * @return ProductSalableResultInterface|MockObject
+     */
+    private function createSalableResult(bool $salable, string $errorMessage = '')
+    {
+        $result = $this->createMock(ProductSalableResultInterface::class);
+        $result->method('isSalable')->willReturn($salable);
+
+        if (!$salable) {
+            $error = $this->createMock(ProductSalabilityErrorInterface::class);
+            $error->method('getMessage')->willReturn($errorMessage);
+            $result->method('getErrors')->willReturn([$error]);
+        }
+
+        return $result;
+    }
+}

--- a/Test/Unit/Model/Order/ShipmentManagerTest.php
+++ b/Test/Unit/Model/Order/ShipmentManagerTest.php
@@ -100,7 +100,8 @@ class ShipmentManagerTest extends TestCase
             $this->originalOrderRepositoryFactory,
             $this->stockQtyManager,
             $this->getSkuFromOrderItem,
-            $this->stockDebugLogger
+            $this->stockDebugLogger,
+            new \MageWorx\OrderEditor\Model\Order\Item\Quantity\ItemQuantitiesResolver()
         );
     }
 

--- a/Test/Unit/Model/Order/ShipmentManagerTest.php
+++ b/Test/Unit/Model/Order/ShipmentManagerTest.php
@@ -129,24 +129,33 @@ class ShipmentManagerTest extends TestCase
         $this->manager->updateShipmentsOnOrderEdit($order);
     }
 
-    public function testModeNothingWithRemovedItemsTriggersRemoveAll(): void
+    /**
+     * "Do not touch" must leave shipments alone even when items are removed —
+     * stock return is owned by the credit memo. (Injecting the MSI manager into
+     * KeepUntouched once made this branch delete shipments — a regression.)
+     */
+    public function testModeNothingDoesNotTouchShipmentsOnRemoval(): void
     {
         $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_NOTHING);
         $order->method('hasRemovedItems')->willReturn(true);
         $order->method('hasItemsWithDecreasedQty')->willReturn(false);
 
-        $this->expectRemoveAllShipmentsCalls($order);
+        $this->shipmentRepository->expects($this->never())->method('delete');
+        $this->stockQtyManager->expects($this->never())->method('cancelShipment');
+        $this->orderRepository->expects($this->never())->method('save');
 
         $this->manager->updateShipmentsOnOrderEdit($order);
     }
 
-    public function testModeNothingWithDecreasedQtyTriggersRemoveAll(): void
+    public function testModeNothingDoesNotTouchShipmentsOnDecrease(): void
     {
         $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_NOTHING);
         $order->method('hasRemovedItems')->willReturn(false);
         $order->method('hasItemsWithDecreasedQty')->willReturn(true);
 
-        $this->expectRemoveAllShipmentsCalls($order);
+        $this->shipmentRepository->expects($this->never())->method('delete');
+        $this->stockQtyManager->expects($this->never())->method('cancelShipment');
+        $this->orderRepository->expects($this->never())->method('save');
 
         $this->manager->updateShipmentsOnOrderEdit($order);
     }

--- a/Test/Unit/Model/Order/ShipmentManagerTest.php
+++ b/Test/Unit/Model/Order/ShipmentManagerTest.php
@@ -22,6 +22,7 @@ use MageWorx\OrderEditor\Api\OrderRepositoryInterface;
 use MageWorx\OrderEditor\Helper\Data as Helper;
 use MageWorx\OrderEditor\Model\Config\Source\Shipments\UpdateMode;
 use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditor\Model\StockDebugLogger;
 use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
 use MageWorx\OrderEditorInventory\Model\Order\ShipmentManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -65,6 +66,9 @@ class ShipmentManagerTest extends TestCase
     /** @var GetSkuFromOrderItemInterface|MockObject */
     private $getSkuFromOrderItem;
 
+    /** @var StockDebugLogger|MockObject */
+    private $stockDebugLogger;
+
     private ShipmentManager $manager;
 
     protected function setUp(): void
@@ -81,6 +85,7 @@ class ShipmentManagerTest extends TestCase
         $this->originalOrderRepositoryFactory = $this->createMock(OriginalOrderRepositoryInterfaceFactory::class);
         $this->stockQtyManager                = $this->createMock(StockQtyManagerInterface::class);
         $this->getSkuFromOrderItem            = $this->createMock(GetSkuFromOrderItemInterface::class);
+        $this->stockDebugLogger               = $this->createMock(StockDebugLogger::class);
 
         $this->manager = new ShipmentManager(
             $this->helperData,
@@ -94,7 +99,8 @@ class ShipmentManagerTest extends TestCase
             $this->originalOrderRepository,
             $this->originalOrderRepositoryFactory,
             $this->stockQtyManager,
-            $this->getSkuFromOrderItem
+            $this->getSkuFromOrderItem,
+            $this->stockDebugLogger
         );
     }
 

--- a/Test/Unit/Model/Order/ShipmentManagerTest.php
+++ b/Test/Unit/Model/Order/ShipmentManagerTest.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Order;
+
+use Magento\Framework\DB\TransactionFactory;
+use Magento\Framework\Registry;
+use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Sales\Api\OrderPaymentRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface as OriginalOrderRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterfaceFactory as OriginalOrderRepositoryInterfaceFactory;
+use Magento\Sales\Api\ShipmentRepositoryInterface;
+use Magento\Sales\Model\Order as SalesOrder;
+use Magento\Shipping\Controller\Adminhtml\Order\ShipmentLoaderFactory;
+use MageWorx\OrderEditor\Api\OrderItemRepositoryInterface;
+use MageWorx\OrderEditor\Api\OrderRepositoryInterface;
+use MageWorx\OrderEditor\Helper\Data as Helper;
+use MageWorx\OrderEditor\Model\Config\Source\Shipments\UpdateMode;
+use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
+use MageWorx\OrderEditorInventory\Model\Order\ShipmentManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ShipmentManagerTest extends TestCase
+{
+    /** @var Helper|MockObject */
+    private $helperData;
+
+    /** @var Registry|MockObject */
+    private $registry;
+
+    /** @var TransactionFactory|MockObject */
+    private $transactionFactory;
+
+    /** @var ShipmentLoaderFactory|MockObject */
+    private $shipmentLoaderFactory;
+
+    /** @var OrderRepositoryInterface|MockObject */
+    private $orderRepository;
+
+    /** @var ShipmentRepositoryInterface|MockObject */
+    private $shipmentRepository;
+
+    /** @var OrderItemRepositoryInterface|MockObject */
+    private $orderItemRepository;
+
+    /** @var OrderPaymentRepositoryInterface|MockObject */
+    private $orderPaymentRepository;
+
+    /** @var OriginalOrderRepositoryInterface|MockObject */
+    private $originalOrderRepository;
+
+    /** @var OriginalOrderRepositoryInterfaceFactory|MockObject */
+    private $originalOrderRepositoryFactory;
+
+    /** @var StockQtyManagerInterface|MockObject */
+    private $stockQtyManager;
+
+    /** @var GetSkuFromOrderItemInterface|MockObject */
+    private $getSkuFromOrderItem;
+
+    private ShipmentManager $manager;
+
+    protected function setUp(): void
+    {
+        $this->helperData                     = $this->createMock(Helper::class);
+        $this->registry                       = $this->createMock(Registry::class);
+        $this->transactionFactory             = $this->createMock(TransactionFactory::class);
+        $this->shipmentLoaderFactory          = $this->createMock(ShipmentLoaderFactory::class);
+        $this->orderRepository                = $this->createMock(OrderRepositoryInterface::class);
+        $this->shipmentRepository             = $this->createMock(ShipmentRepositoryInterface::class);
+        $this->orderItemRepository            = $this->createMock(OrderItemRepositoryInterface::class);
+        $this->orderPaymentRepository         = $this->createMock(OrderPaymentRepositoryInterface::class);
+        $this->originalOrderRepository        = $this->createMock(OriginalOrderRepositoryInterface::class);
+        $this->originalOrderRepositoryFactory = $this->createMock(OriginalOrderRepositoryInterfaceFactory::class);
+        $this->stockQtyManager                = $this->createMock(StockQtyManagerInterface::class);
+        $this->getSkuFromOrderItem            = $this->createMock(GetSkuFromOrderItemInterface::class);
+
+        $this->manager = new ShipmentManager(
+            $this->helperData,
+            $this->registry,
+            $this->transactionFactory,
+            $this->shipmentLoaderFactory,
+            $this->orderRepository,
+            $this->shipmentRepository,
+            $this->orderItemRepository,
+            $this->orderPaymentRepository,
+            $this->originalOrderRepository,
+            $this->originalOrderRepositoryFactory,
+            $this->stockQtyManager,
+            $this->getSkuFromOrderItem
+        );
+    }
+
+    public function testReturnsOrderEarlyWhenNoShipments(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('hasShipments')->willReturn(false);
+
+        $this->helperData->expects($this->never())->method('getUpdateShipmentMode');
+        $this->shipmentRepository->expects($this->never())->method('delete');
+
+        $result = $this->manager->updateShipmentsOnOrderEdit($order);
+        $this->assertSame($order, $result);
+    }
+
+    public function testModeNothingWithoutDecreasesIsNoOp(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_NOTHING);
+        $order->method('hasRemovedItems')->willReturn(false);
+        $order->method('hasItemsWithDecreasedQty')->willReturn(false);
+
+        $this->shipmentRepository->expects($this->never())->method('delete');
+        $this->orderRepository->expects($this->never())->method('save');
+        $this->orderPaymentRepository->expects($this->never())->method('save');
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    public function testModeNothingWithRemovedItemsTriggersRemoveAll(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_NOTHING);
+        $order->method('hasRemovedItems')->willReturn(true);
+        $order->method('hasItemsWithDecreasedQty')->willReturn(false);
+
+        $this->expectRemoveAllShipmentsCalls($order);
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    public function testModeNothingWithDecreasedQtyTriggersRemoveAll(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_NOTHING);
+        $order->method('hasRemovedItems')->willReturn(false);
+        $order->method('hasItemsWithDecreasedQty')->willReturn(true);
+
+        $this->expectRemoveAllShipmentsCalls($order);
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    public function testModeRebuildAlwaysRemovesAndCreates(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_REBUILD);
+        $order->method('canShip')->willReturn(false);
+
+        $this->expectRemoveAllShipmentsCalls($order);
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    public function testModeAddWithOnlyIncreasedQtyDoesNotRemoveFirst(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_ADD);
+        $order->method('hasItemsWithIncreasedQty')->willReturn(true);
+        $order->method('hasAddedItems')->willReturn(false);
+        $order->method('hasItemsWithDecreasedQty')->willReturn(false);
+        $order->method('hasRemovedItems')->willReturn(false);
+        $order->method('canShip')->willReturn(false);
+
+        $this->orderRepository->expects($this->never())->method('save');
+        $this->orderPaymentRepository->expects($this->never())->method('save');
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    public function testModeAddWithMixedChangesRemovesFirst(): void
+    {
+        $order = $this->createOrderForMode(UpdateMode::MODE_UPDATE_ADD);
+        $order->method('hasItemsWithIncreasedQty')->willReturn(true);
+        $order->method('hasAddedItems')->willReturn(false);
+        $order->method('hasItemsWithDecreasedQty')->willReturn(true);
+        $order->method('hasRemovedItems')->willReturn(false);
+        $order->method('canShip')->willReturn(false);
+
+        $this->expectRemoveAllShipmentsCalls($order);
+
+        $this->manager->updateShipmentsOnOrderEdit($order);
+    }
+
+    /**
+     * @param string $mode
+     * @return Order|MockObject
+     */
+    private function createOrderForMode(string $mode)
+    {
+        $this->helperData->method('getUpdateShipmentMode')->willReturn($mode);
+
+        $order = $this->createMock(Order::class);
+        $order->method('hasShipments')->willReturn(true);
+        $order->method('getShipmentsCollection')->willReturn(new \ArrayIterator([]));
+        $order->method('getItems')->willReturn([]);
+
+        return $order;
+    }
+
+    /**
+     * @param Order|MockObject $order
+     */
+    private function expectRemoveAllShipmentsCalls($order): void
+    {
+        $payment = $this->createMock(OrderPaymentInterface::class);
+        $payment->method('setShippingCaptured')->willReturnSelf();
+        $payment->method('setBaseShippingCaptured')->willReturnSelf();
+        $payment->method('setShippingRefunded')->willReturnSelf();
+        $payment->method('setBaseShippingRefunded')->willReturnSelf();
+        $order->method('getPayment')->willReturn($payment);
+
+        $order->expects($this->once())->method('setState')->with(SalesOrder::STATE_PROCESSING);
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
+        $this->orderPaymentRepository->expects($this->once())->method('save')->with($payment);
+    }
+}

--- a/Test/Unit/Model/Stock/BackorderPolicyTest.php
+++ b/Test/Unit/Model/Stock/BackorderPolicyTest.php
@@ -1,0 +1,84 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Stock;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\InventoryConfigurationApi\Api\Data\StockItemConfigurationInterface;
+use Magento\InventoryConfigurationApi\Api\GetStockItemConfigurationInterface;
+use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use MageWorx\OrderEditorInventory\Model\Stock\BackorderPolicy;
+use PHPUnit\Framework\TestCase;
+
+class BackorderPolicyTest extends TestCase
+{
+    private const SKU = 'cfg-1-XL';
+    private const WEBSITE_ID = 1;
+    private const STOCK_ID = 7;
+
+    /**
+     * @dataProvider backordersProvider
+     */
+    public function testReturnsTrueWhenBackordersEnabled(int $backordersValue, bool $expected): void
+    {
+        $policy = $this->buildPolicy($backordersValue);
+
+        self::assertSame($expected, $policy->isBackorderAllowed(self::SKU, self::WEBSITE_ID));
+    }
+
+    /**
+     * @return array<string, array{0: int, 1: bool}>
+     */
+    public static function backordersProvider(): array
+    {
+        return [
+            'no backorders'       => [0, false],
+            'backorders yes'      => [1, true],
+            'backorders + notify' => [2, true],
+        ];
+    }
+
+    public function testReturnsFalseWhenConfigurationUnreadable(): void
+    {
+        $websiteRepository = $this->createMock(WebsiteRepositoryInterface::class);
+        $websiteRepository->method('getById')
+            ->willThrowException(new \Magento\Framework\Exception\NoSuchEntityException(__('no website')));
+
+        $policy = (new ObjectManagerHelper($this))->getObject(BackorderPolicy::class, [
+            'websiteRepository' => $websiteRepository,
+        ]);
+
+        self::assertFalse(
+            $policy->isBackorderAllowed(self::SKU, self::WEBSITE_ID),
+            'conservative default — no backorders when config cannot be read'
+        );
+    }
+
+    private function buildPolicy(int $backordersValue): BackorderPolicy
+    {
+        $website = $this->createMock(WebsiteInterface::class);
+        $website->method('getCode')->willReturn('base');
+        $websiteRepository = $this->createMock(WebsiteRepositoryInterface::class);
+        $websiteRepository->method('getById')->with(self::WEBSITE_ID)->willReturn($website);
+
+        $stock = $this->createMock(StockInterface::class);
+        $stock->method('getStockId')->willReturn(self::STOCK_ID);
+        $stockResolver = $this->createMock(StockResolverInterface::class);
+        $stockResolver->method('execute')->willReturn($stock);
+
+        $config = $this->createMock(StockItemConfigurationInterface::class);
+        $config->method('getBackorders')->willReturn($backordersValue);
+        $getConfig = $this->createMock(GetStockItemConfigurationInterface::class);
+        $getConfig->method('execute')->with(self::SKU, self::STOCK_ID)->willReturn($config);
+
+        return (new ObjectManagerHelper($this))->getObject(BackorderPolicy::class, [
+            'getStockItemConfiguration' => $getConfig,
+            'stockResolver'             => $stockResolver,
+            'websiteRepository'         => $websiteRepository,
+        ]);
+    }
+}

--- a/Test/Unit/Model/Stock/MsiSwapPhysicalExchangeTest.php
+++ b/Test/Unit/Model/Stock/MsiSwapPhysicalExchangeTest.php
@@ -1,0 +1,237 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Stock;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Model\Order;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Store\Model\Store;
+use MageWorx\OrderEditor\Model\StockDebugLogger;
+use MageWorx\OrderEditorInventory\Model\Stock\MsiSwapPhysicalExchange;
+use MageWorx\OrderEditorInventory\Model\Stock\SourceCodeResolver;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MsiSwapPhysicalExchangeTest extends TestCase
+{
+    private SourceCodeResolver|MockObject $resolver;
+    private GetSourceItemsBySkuInterface|MockObject $getSourceItemsBySku;
+    private SourceItemsSaveInterface|MockObject $sourceItemsSave;
+    private PlaceReservationsForSalesEventInterface|MockObject $placeReservations;
+    private MessageManagerInterface|MockObject $messageManager;
+    private MsiSwapPhysicalExchange $service;
+    private array $sourceItemsBySku = [];
+
+    protected function setUp(): void
+    {
+        $this->sourceItemsBySku = [];
+        $this->resolver = $this->createMock(SourceCodeResolver::class);
+        $this->getSourceItemsBySku = $this->createMock(GetSourceItemsBySkuInterface::class);
+        $this->sourceItemsSave = $this->createMock(SourceItemsSaveInterface::class);
+        $this->placeReservations = $this->createMock(PlaceReservationsForSalesEventInterface::class);
+        $this->messageManager = $this->createMock(MessageManagerInterface::class);
+
+        $salesEventFactory = $this->createMock(SalesEventInterfaceFactory::class);
+        $salesEventFactory->method('create')->willReturnCallback(function () {
+            $event = $this->createMock(SalesEventInterface::class);
+            $event->method('getType')->willReturn('');
+            return $event;
+        });
+        $salesEventExtensionFactory = $this->createMock(SalesEventExtensionFactory::class);
+        $salesEventExtensionFactory->method('create')
+            ->willReturn($this->createMock(SalesEventExtensionInterface::class));
+        $salesChannelFactory = $this->createMock(SalesChannelInterfaceFactory::class);
+        $salesChannelFactory->method('create')
+            ->willReturn($this->createMock(SalesChannelInterface::class));
+        $itemsToSellFactory = $this->createMock(ItemToSellInterfaceFactory::class);
+        $itemsToSellFactory->method('create')
+            ->willReturn($this->createMock(ItemToSellInterface::class));
+
+        $websiteRepo = $this->createMock(WebsiteRepositoryInterface::class);
+        $website = $this->createMock(WebsiteInterface::class);
+        $website->method('getCode')->willReturn('base');
+        $websiteRepo->method('getById')->willReturn($website);
+
+        $stockDebugLogger = $this->createMock(StockDebugLogger::class);
+
+        // Single callback that respects per-test sourceItemsBySku map.
+        $this->getSourceItemsBySku->method('execute')
+            ->willReturnCallback(fn(string $sku) => $this->sourceItemsBySku[$sku] ?? []);
+
+        $this->service = new MsiSwapPhysicalExchange(
+            $this->resolver,
+            $this->getSourceItemsBySku,
+            $this->sourceItemsSave,
+            $this->placeReservations,
+            $salesEventFactory,
+            $salesEventExtensionFactory,
+            $salesChannelFactory,
+            $websiteRepo,
+            $itemsToSellFactory,
+            $this->messageManager,
+            $stockDebugLogger
+        );
+    }
+
+    public function testValidatePassesWhenSourcesAreSufficient(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn(['default' => 2.0]);
+        $this->resolver->method('findDeductionSource')
+            ->with('cfg-1-XL', 1, 2.0, 'default')
+            ->willReturn('default');
+
+        $this->service->validate($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+        self::assertTrue(true); // no exception
+    }
+
+    public function testValidateThrowsWhenNoDeductionSource(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn(['default' => 2.0]);
+        $this->resolver->method('findDeductionSource')->willReturn(null);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/Cannot deduct/');
+        $this->service->validate($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+    }
+
+    public function testValidateThrowsWhenOldSkuHasNoSourceAndShipmentSourceMissing(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn([]);
+        $this->getSourceItemsBySku->method('execute')->willReturn([]);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/no source is configured/');
+        $this->service->validate($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+    }
+
+    public function testValidateNoOpForZeroQty(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->expects(self::never())->method('resolveShipmentSources');
+        $this->service->validate($order, $item, 'cfg-1-XS', 'cfg-1-XL', 0.0);
+    }
+
+    public function testExecuteReturnsOldSkuToShipmentSourceAndDeductsNewFromSame(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn(['default' => 2.0]);
+        $this->resolver->method('findReturnSource')->willReturn('default');
+        $this->resolver->method('findDeductionSource')->willReturn('default');
+
+        $this->mockSourceItemForSku('cfg-1-XS', 'default', 17.0);
+        $this->mockSourceItemForSku('cfg-1-XL', 'default', 5.0);
+
+        // Two source updates: +2 to XS, -2 from XL.
+        $this->sourceItemsSave->expects(self::exactly(2))->method('execute');
+
+        // No reservation pair — shipped qty placement is already balanced by
+        // shipment_created (see MsiSwapPhysicalExchange::execute comment).
+        // History log entry lives elsewhere (ProductOptionsEditor).
+        $this->placeReservations->expects(self::never())->method('execute');
+
+        // No notice when same source served both legs.
+        $this->messageManager->expects(self::never())->method('addNoticeMessage');
+
+        $this->service->execute($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+    }
+
+    public function testExecuteEmitsNoticeWhenDeductionFallsBackToDifferentSource(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn(['default' => 2.0]);
+        $this->resolver->method('findReturnSource')->willReturn('default');
+        // Fallback path: shipment source is `default` but new SKU deducted from `eu_source`.
+        $this->resolver->method('findDeductionSource')->willReturn('eu_source');
+
+        $this->mockSourceItemForSku('cfg-1-XS', 'default', 17.0);
+        $this->mockSourceItemForSku('cfg-1-XL', 'eu_source', 10.0);
+
+        $this->sourceItemsSave->expects(self::exactly(2))->method('execute');
+        $this->placeReservations->expects(self::never())->method('execute');
+        $this->messageManager->expects(self::once())->method('addNoticeMessage');
+
+        $this->service->execute($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+    }
+
+    public function testExecuteThrowsWhenDeductionSourceUnresolvableAtRuntime(): void
+    {
+        $order = $this->buildOrder();
+        $item = $this->buildOrderItem();
+
+        $this->resolver->method('resolveShipmentSources')->willReturn(['default' => 2.0]);
+        $this->resolver->method('findReturnSource')->willReturn('default');
+        $this->resolver->method('findDeductionSource')->willReturn(null);
+
+        $this->mockSourceItemForSku('cfg-1-XS', 'default', 17.0);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessageMatches('/Stock changed during exchange/');
+        $this->service->execute($order, $item, 'cfg-1-XS', 'cfg-1-XL', 2.0);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────
+
+    private function buildOrder(): Order|MockObject
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getWebsiteId')->willReturn(1);
+        $order = $this->createMock(Order::class);
+        $order->method('getStore')->willReturn($store);
+        $order->method('getId')->willReturn(123);
+        $order->method('getEntityId')->willReturn(123);
+        $order->method('getIncrementId')->willReturn('ORD-TEST-001');
+        return $order;
+    }
+
+    private function buildOrderItem(): OrderItemInterface|MockObject
+    {
+        $item = $this->createMock(OrderItemInterface::class);
+        $item->method('getItemId')->willReturn(456);
+        return $item;
+    }
+
+    private function mockSourceItemForSku(string $sku, string $sourceCode, float $qty): void
+    {
+        $sourceItem = $this->createMock(SourceItemInterface::class);
+        $sourceItem->method('getSourceCode')->willReturn($sourceCode);
+        $sourceItem->method('getQuantity')->willReturn($qty);
+        $sourceItem->method('getStatus')->willReturn(SourceItemInterface::STATUS_IN_STOCK);
+        $sourceItem->expects(self::any())->method('setQuantity');
+        $sourceItem->expects(self::any())->method('setStatus');
+
+        $this->sourceItemsBySku[$sku] = [$sourceItem];
+    }
+}

--- a/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
+++ b/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
@@ -14,9 +14,13 @@ use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
 use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
 use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
 use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
 use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Store\Api\Data\WebsiteInterface;
 use Magento\Store\Api\WebsiteRepositoryInterface;
 use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
 use MageWorx\OrderEditorInventory\Model\Stock\MultiSourceInventoryManager;
@@ -37,24 +41,48 @@ class MultiSourceInventoryManagerTest extends TestCase
     /** @var SourceItemsSaveInterface|MockObject */
     private $sourceItemsSave;
 
+    /** @var ItemToSellInterfaceFactory|MockObject */
+    private $itemsToSellFactory;
+
+    /** @var PlaceReservationsForSalesEventInterface|MockObject */
+    private $placeReservationsForSalesEvent;
+
+    /** @var SalesEventInterfaceFactory|MockObject */
+    private $salesEventFactory;
+
+    /** @var SalesEventExtensionFactory|MockObject */
+    private $salesEventExtensionFactory;
+
+    /** @var SalesChannelInterfaceFactory|MockObject */
+    private $salesChannelFactory;
+
+    /** @var WebsiteRepositoryInterface|MockObject */
+    private $websiteRepository;
+
     private MultiSourceInventoryManager $manager;
 
     protected function setUp(): void
     {
-        $this->stockQtyManager     = $this->createMock(StockQtyManagerInterface::class);
-        $this->getSkusByProductIds = $this->createMock(GetSkusByProductIdsInterface::class);
-        $this->getSourceItemsBySku = $this->createMock(GetSourceItemsBySkuInterface::class);
-        $this->sourceItemsSave     = $this->createMock(SourceItemsSaveInterface::class);
+        $this->stockQtyManager                = $this->createMock(StockQtyManagerInterface::class);
+        $this->getSkusByProductIds            = $this->createMock(GetSkusByProductIdsInterface::class);
+        $this->getSourceItemsBySku            = $this->createMock(GetSourceItemsBySkuInterface::class);
+        $this->sourceItemsSave                = $this->createMock(SourceItemsSaveInterface::class);
+        $this->itemsToSellFactory             = $this->createMock(ItemToSellInterfaceFactory::class);
+        $this->placeReservationsForSalesEvent = $this->createMock(PlaceReservationsForSalesEventInterface::class);
+        $this->salesEventFactory              = $this->createMock(SalesEventInterfaceFactory::class);
+        $this->salesEventExtensionFactory     = $this->createMock(SalesEventExtensionFactory::class);
+        $this->salesChannelFactory            = $this->createMock(SalesChannelInterfaceFactory::class);
+        $this->websiteRepository              = $this->createMock(WebsiteRepositoryInterface::class);
 
         $this->manager = new MultiSourceInventoryManager(
             $this->stockQtyManager,
             $this->getSkusByProductIds,
-            $this->createMock(ItemToSellInterfaceFactory::class),
-            $this->createMock(PlaceReservationsForSalesEventInterface::class),
-            $this->createMock(SalesEventInterfaceFactory::class),
-            $this->createMock(SalesEventExtensionFactory::class),
-            $this->createMock(SalesChannelInterfaceFactory::class),
-            $this->createMock(WebsiteRepositoryInterface::class),
+            $this->itemsToSellFactory,
+            $this->placeReservationsForSalesEvent,
+            $this->salesEventFactory,
+            $this->salesEventExtensionFactory,
+            $this->salesChannelFactory,
+            $this->websiteRepository,
             $this->getSourceItemsBySku,
             $this->sourceItemsSave
         );
@@ -129,5 +157,132 @@ class MultiSourceInventoryManagerTest extends TestCase
         $this->sourceItemsSave->expects($this->never())->method('execute');
 
         $this->manager->registerReturnByProductId(5, 1.0, 1);
+    }
+
+    /**
+     * Roadmap §4.2.3 — when called with negative qty AND an order context,
+     * the swapped-in SKU must get paired reservations
+     * (ORDER_PLACED -|qty| + SHIPMENT_CREATED +|qty|).
+     */
+    public function testRegisterReturnByProductIdPlacesPairedReservationsOnDeductWithOrder(): void
+    {
+        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
+        $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
+        $this->setUpWebsite(1, 'base');
+
+        // 4 factory calls: salesChannel, extension, ORDER_PLACED event, SHIPMENT_CREATED event
+        $this->salesChannelFactory->expects($this->once())->method('create')
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\SalesChannelInterface::class));
+        $this->salesEventExtensionFactory->expects($this->once())->method('create')
+            ->willReturn($this->createMock(SalesEventExtensionInterface::class));
+
+        $orderPlacedEvent = $this->createMock(SalesEventInterface::class);
+        $shipmentEvent    = $this->createMock(SalesEventInterface::class);
+        $this->salesEventFactory->expects($this->exactly(2))->method('create')
+            ->willReturnOnConsecutiveCalls($orderPlacedEvent, $shipmentEvent);
+
+        // 2 ItemToSell: one for -2, one for +2
+        $itemToSellNegative = $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class);
+        $itemToSellPositive = $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class);
+        $factoryCalls = [];
+        $this->itemsToSellFactory->expects($this->exactly(2))->method('create')
+            ->willReturnCallback(function (array $args) use (&$factoryCalls, $itemToSellNegative, $itemToSellPositive) {
+                $factoryCalls[] = $args;
+                return $args['qty'] < 0 ? $itemToSellNegative : $itemToSellPositive;
+            });
+
+        // placeReservationsForSalesEvent called twice: once for each event
+        $this->placeReservationsForSalesEvent->expects($this->exactly(2))->method('execute');
+
+        $this->manager->registerReturnByProductId(254, -2.0, 1, $order);
+
+        // Verify factory was called with correct sku/qty pairs
+        $this->assertCount(2, $factoryCalls);
+        $this->assertSame('MH09-XL-Blue', $factoryCalls[0]['sku']);
+        $this->assertSame(-2.0, $factoryCalls[0]['qty']);
+        $this->assertSame('MH09-XL-Blue', $factoryCalls[1]['sku']);
+        $this->assertSame(2.0, $factoryCalls[1]['qty']);
+    }
+
+    /**
+     * Without an order, no paired reservations — backward compat with old callers.
+     */
+    public function testRegisterReturnByProductIdSkipsPairedReservationsWithoutOrder(): void
+    {
+        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
+
+        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
+        $this->salesChannelFactory->expects($this->never())->method('create');
+        $this->salesEventFactory->expects($this->never())->method('create');
+
+        $this->manager->registerReturnByProductId(254, -2.0, 1);
+    }
+
+    /**
+     * Positive qty (return case) does NOT create paired reservations even with order —
+     * the old SKU's existing reservations remain untouched (we don't manufacture
+     * compensation for them).
+     */
+    public function testRegisterReturnByProductIdSkipsPairedReservationsOnPositiveQty(): void
+    {
+        $this->setUpEnabledSource('MH09-L-Red', 98.0);
+        $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
+
+        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
+
+        $this->manager->registerReturnByProductId(99, 2.0, 1, $order);
+    }
+
+    /**
+     * Reservation creation failure must not abort the flow — source_item update
+     * (the user-visible part) has already happened.
+     */
+    public function testRegisterReturnByProductIdSwallowsReservationException(): void
+    {
+        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
+        $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
+        $this->setUpWebsite(1, 'base');
+
+        $this->salesChannelFactory->method('create')
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\SalesChannelInterface::class));
+        $this->salesEventExtensionFactory->method('create')
+            ->willReturn($this->createMock(SalesEventExtensionInterface::class));
+        $this->salesEventFactory->method('create')
+            ->willReturn($this->createMock(SalesEventInterface::class));
+        $this->itemsToSellFactory->method('create')
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class));
+
+        $this->placeReservationsForSalesEvent->method('execute')
+            ->willThrowException(new \RuntimeException('MSI broke'));
+
+        // Must not propagate
+        $this->manager->registerReturnByProductId(254, -2.0, 1, $order);
+        $this->addToAssertionCount(1);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────
+
+    private function setUpEnabledSource(string $sku, float $qty): void
+    {
+        $this->getSkusByProductIds->method('execute')->willReturn([$sku === 'MH09-L-Red' ? 99 : 254 => $sku]);
+        $enabled = $this->createMock(SourceItemInterface::class);
+        $enabled->method('getStatus')->willReturn(1);
+        $enabled->method('getQuantity')->willReturn($qty);
+        $this->getSourceItemsBySku->method('execute')->willReturn([$enabled]);
+    }
+
+    private function setUpWebsite(int $websiteId, string $code): void
+    {
+        $website = $this->createMock(WebsiteInterface::class);
+        $website->method('getCode')->willReturn($code);
+        $this->websiteRepository->method('getById')->with($websiteId)->willReturn($website);
+    }
+
+    private function createOrderMock(int $entityId, string $incrementId): OrderInterface
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn($entityId);
+        $order->method('getIncrementId')->willReturn($incrementId);
+        return $order;
     }
 }

--- a/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
+++ b/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
@@ -160,86 +160,107 @@ class MultiSourceInventoryManagerTest extends TestCase
     }
 
     /**
-     * Roadmap §4.2.3 — when called with negative qty AND an order context,
-     * the swapped-in SKU must get paired reservations
-     * (ORDER_PLACED -|qty| + SHIPMENT_CREATED +|qty|).
+     * Roadmap §4.2.6 — when called with negative qty AND an order context,
+     * places ONE reservation (ORDER_PLACED -qty) on the new SKU; does NOT
+     * touch the source_item (no physical event yet, only logical swap of
+     * the pending portion).
      */
-    public function testRegisterReturnByProductIdPlacesPairedReservationsOnDeductWithOrder(): void
+    public function testRegisterReturnByProductIdPlacesOrderPlacedReservationOnDeductWithOrder(): void
     {
-        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
+        $this->getSkusByProductIds->method('execute')->willReturn([254 => 'MH09-XL-Blue']);
         $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
         $this->setUpWebsite(1, 'base');
 
-        // 4 factory calls: salesChannel, extension, ORDER_PLACED event, SHIPMENT_CREATED event
+        // No source_item update in configure-swap mode
+        $this->getSourceItemsBySku->expects($this->never())->method('execute');
+        $this->sourceItemsSave->expects($this->never())->method('execute');
+
         $this->salesChannelFactory->expects($this->once())->method('create')
             ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\SalesChannelInterface::class));
         $this->salesEventExtensionFactory->expects($this->once())->method('create')
             ->willReturn($this->createMock(SalesEventExtensionInterface::class));
 
+        // ONE event: ORDER_PLACED only (no SHIPMENT_CREATED — pending isn't shipped yet)
         $orderPlacedEvent = $this->createMock(SalesEventInterface::class);
-        $shipmentEvent    = $this->createMock(SalesEventInterface::class);
-        $this->salesEventFactory->expects($this->exactly(2))->method('create')
-            ->willReturnOnConsecutiveCalls($orderPlacedEvent, $shipmentEvent);
+        $this->salesEventFactory->expects($this->once())->method('create')
+            ->with(self::callback(fn ($args) => ($args['type'] ?? null) === SalesEventInterface::EVENT_ORDER_PLACED))
+            ->willReturn($orderPlacedEvent);
 
-        // 2 ItemToSell: one for -2, one for +2
-        $itemToSellNegative = $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class);
-        $itemToSellPositive = $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class);
-        $factoryCalls = [];
-        $this->itemsToSellFactory->expects($this->exactly(2))->method('create')
-            ->willReturnCallback(function (array $args) use (&$factoryCalls, $itemToSellNegative, $itemToSellPositive) {
-                $factoryCalls[] = $args;
-                return $args['qty'] < 0 ? $itemToSellNegative : $itemToSellPositive;
-            });
+        $this->itemsToSellFactory->expects($this->once())->method('create')
+            ->with(self::callback(
+                fn ($args) => ($args['sku'] ?? null) === 'MH09-XL-Blue' && ($args['qty'] ?? null) === -2.0
+            ))
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class));
 
-        // placeReservationsForSalesEvent called twice: once for each event
-        $this->placeReservationsForSalesEvent->expects($this->exactly(2))->method('execute');
+        $this->placeReservationsForSalesEvent->expects($this->once())->method('execute');
 
         $this->manager->registerReturnByProductId(254, -2.0, 1, $order);
-
-        // Verify factory was called with correct sku/qty pairs
-        $this->assertCount(2, $factoryCalls);
-        $this->assertSame('MH09-XL-Blue', $factoryCalls[0]['sku']);
-        $this->assertSame(-2.0, $factoryCalls[0]['qty']);
-        $this->assertSame('MH09-XL-Blue', $factoryCalls[1]['sku']);
-        $this->assertSame(2.0, $factoryCalls[1]['qty']);
     }
 
     /**
-     * Without an order, no paired reservations — backward compat with old callers.
+     * Roadmap §4.2.6 — positive qty WITH order context releases the old SKU's
+     * pending reservation via ORDER_CANCELED event.
      */
-    public function testRegisterReturnByProductIdSkipsPairedReservationsWithoutOrder(): void
+    public function testRegisterReturnByProductIdPlacesOrderCanceledReservationOnReleaseWithOrder(): void
     {
-        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
-
-        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
-        $this->salesChannelFactory->expects($this->never())->method('create');
-        $this->salesEventFactory->expects($this->never())->method('create');
-
-        $this->manager->registerReturnByProductId(254, -2.0, 1);
-    }
-
-    /**
-     * Positive qty (return case) does NOT create paired reservations even with order —
-     * the old SKU's existing reservations remain untouched (we don't manufacture
-     * compensation for them).
-     */
-    public function testRegisterReturnByProductIdSkipsPairedReservationsOnPositiveQty(): void
-    {
-        $this->setUpEnabledSource('MH09-L-Red', 98.0);
+        $this->getSkusByProductIds->method('execute')->willReturn([99 => 'MH09-L-Red']);
         $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
+        $this->setUpWebsite(1, 'base');
 
-        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
+        // No source_item update
+        $this->getSourceItemsBySku->expects($this->never())->method('execute');
+        $this->sourceItemsSave->expects($this->never())->method('execute');
+
+        $this->salesChannelFactory->method('create')
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\SalesChannelInterface::class));
+        $this->salesEventExtensionFactory->method('create')
+            ->willReturn($this->createMock(SalesEventExtensionInterface::class));
+
+        // ORDER_CANCELED event for release (not ORDER_PLACED)
+        $this->salesEventFactory->expects($this->once())->method('create')
+            ->with(self::callback(fn ($args) => ($args['type'] ?? null) === 'order_canceled'))
+            ->willReturn($this->createMock(SalesEventInterface::class));
+
+        $this->itemsToSellFactory->expects($this->once())->method('create')
+            ->with(self::callback(
+                fn ($args) => ($args['sku'] ?? null) === 'MH09-L-Red' && ($args['qty'] ?? null) === 2.0
+            ))
+            ->willReturn($this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class));
+
+        $this->placeReservationsForSalesEvent->expects($this->once())->method('execute');
 
         $this->manager->registerReturnByProductId(99, 2.0, 1, $order);
     }
 
     /**
-     * Reservation creation failure must not abort the flow — source_item update
-     * (the user-visible part) has already happened.
+     * Without an order, no reservations — legacy mode falls through to direct
+     * source_item adjustment (BC for callers that pass only 3 args).
+     */
+    public function testRegisterReturnByProductIdLegacyModeWithoutOrder(): void
+    {
+        $this->getSkusByProductIds->method('execute')->willReturn([254 => 'MH09-XL-Blue']);
+        $enabled = $this->createMock(SourceItemInterface::class);
+        $enabled->method('getStatus')->willReturn(1);
+        $enabled->method('getQuantity')->willReturn(87.0);
+        $enabled->expects($this->once())->method('setQuantity')->with(85.0);
+        $this->getSourceItemsBySku->method('execute')->willReturn([$enabled]);
+        $this->sourceItemsSave->expects($this->once())->method('execute');
+
+        // No reservations created
+        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
+        $this->salesChannelFactory->expects($this->never())->method('create');
+
+        $this->manager->registerReturnByProductId(254, -2.0, 1);
+    }
+
+    /**
+     * Reservation creation failure must not abort the Configure swap.
+     * Configure swap proceeds even if MSI hiccups; salable drift on the
+     * affected SKU is the worst outcome.
      */
     public function testRegisterReturnByProductIdSwallowsReservationException(): void
     {
-        $this->setUpEnabledSource('MH09-XL-Blue', 87.0);
+        $this->getSkusByProductIds->method('execute')->willReturn([254 => 'MH09-XL-Blue']);
         $order = $this->createOrderMock(210, 'ORD-26-04-28-150');
         $this->setUpWebsite(1, 'base');
 

--- a/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
+++ b/Test/Unit/Model/Stock/MultiSourceInventoryManagerTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Stock;
+
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceItemsSaveInterface;
+use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use MageWorx\OrderEditorInventory\Api\StockQtyManagerInterface;
+use MageWorx\OrderEditorInventory\Model\Stock\MultiSourceInventoryManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MultiSourceInventoryManagerTest extends TestCase
+{
+    /** @var StockQtyManagerInterface|MockObject */
+    private $stockQtyManager;
+
+    /** @var GetSkusByProductIdsInterface|MockObject */
+    private $getSkusByProductIds;
+
+    /** @var GetSourceItemsBySkuInterface|MockObject */
+    private $getSourceItemsBySku;
+
+    /** @var SourceItemsSaveInterface|MockObject */
+    private $sourceItemsSave;
+
+    private MultiSourceInventoryManager $manager;
+
+    protected function setUp(): void
+    {
+        $this->stockQtyManager     = $this->createMock(StockQtyManagerInterface::class);
+        $this->getSkusByProductIds = $this->createMock(GetSkusByProductIdsInterface::class);
+        $this->getSourceItemsBySku = $this->createMock(GetSourceItemsBySkuInterface::class);
+        $this->sourceItemsSave     = $this->createMock(SourceItemsSaveInterface::class);
+
+        $this->manager = new MultiSourceInventoryManager(
+            $this->stockQtyManager,
+            $this->getSkusByProductIds,
+            $this->createMock(ItemToSellInterfaceFactory::class),
+            $this->createMock(PlaceReservationsForSalesEventInterface::class),
+            $this->createMock(SalesEventInterfaceFactory::class),
+            $this->createMock(SalesEventExtensionFactory::class),
+            $this->createMock(SalesChannelInterfaceFactory::class),
+            $this->createMock(WebsiteRepositoryInterface::class),
+            $this->getSourceItemsBySku,
+            $this->sourceItemsSave
+        );
+    }
+
+    public function testRegisterSaleDelegatesToStockQtyManager(): void
+    {
+        $item = $this->createMock(OrderItem::class);
+        $this->stockQtyManager->expects($this->once())
+                              ->method('deductQtyFromStock')
+                              ->with($item, 4.0);
+        $this->manager->registerSale($item, 4.0);
+    }
+
+    public function testRegisterReturnDelegatesToStockQtyManager(): void
+    {
+        $item = $this->createMock(OrderItem::class);
+        $this->stockQtyManager->expects($this->once())
+                              ->method('returnQtyToStock')
+                              ->with($item, 2.0);
+        $this->manager->registerReturn($item, 2.0);
+    }
+
+    public function testRegisterReturnByProductIdAdjustsFirstEnabledSource(): void
+    {
+        $this->getSkusByProductIds->method('execute')->with([5])->willReturn([5 => 'sku-x']);
+
+        $disabled = $this->createMock(SourceItemInterface::class);
+        $disabled->method('getStatus')->willReturn(0);
+        $disabled->expects($this->never())->method('setQuantity');
+
+        $enabled = $this->createMock(SourceItemInterface::class);
+        $enabled->method('getStatus')->willReturn(1);
+        $enabled->method('getQuantity')->willReturn(10.0);
+        $enabled->expects($this->once())->method('setQuantity')->with(13.0);
+
+        $this->getSourceItemsBySku->method('execute')->with('sku-x')->willReturn([$disabled, $enabled]);
+
+        $this->sourceItemsSave->expects($this->once())->method('execute')->with([$enabled]);
+
+        $this->manager->registerReturnByProductId(5, 3.0, 1);
+    }
+
+    public function testRegisterReturnByProductIdNegativeQtyClampsToZero(): void
+    {
+        $this->getSkusByProductIds->method('execute')->willReturn([5 => 'sku-x']);
+
+        $enabled = $this->createMock(SourceItemInterface::class);
+        $enabled->method('getStatus')->willReturn(1);
+        $enabled->method('getQuantity')->willReturn(2.0);
+        $enabled->expects($this->once())->method('setQuantity')->with(0.0);
+
+        $this->getSourceItemsBySku->method('execute')->willReturn([$enabled]);
+        $this->sourceItemsSave->expects($this->once())->method('execute');
+
+        $this->manager->registerReturnByProductId(5, -5.0, 1);
+    }
+
+    public function testRegisterReturnByProductIdReturnsEarlyWhenSkuMissing(): void
+    {
+        $this->getSkusByProductIds->method('execute')->willReturn([]);
+        $this->getSourceItemsBySku->expects($this->never())->method('execute');
+        $this->sourceItemsSave->expects($this->never())->method('execute');
+
+        $this->manager->registerReturnByProductId(99, 1.0, 1);
+    }
+
+    public function testRegisterReturnByProductIdReturnsEarlyWhenNoSourceItems(): void
+    {
+        $this->getSkusByProductIds->method('execute')->willReturn([5 => 'sku-x']);
+        $this->getSourceItemsBySku->method('execute')->willReturn([]);
+        $this->sourceItemsSave->expects($this->never())->method('execute');
+
+        $this->manager->registerReturnByProductId(5, 1.0, 1);
+    }
+}

--- a/Test/Unit/Model/Stock/ReturnProcessor/GetItemsToReturnPerSourceTest.php
+++ b/Test/Unit/Model/Stock/ReturnProcessor/GetItemsToReturnPerSourceTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Stock\ReturnProcessor;
+
+use Magento\InventoryApi\Api\Data\SourceInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\GetSourcesAssignedToStockOrderedByPriorityInterface;
+use Magento\InventoryCatalogApi\Api\DefaultSourceProviderInterface;
+use Magento\InventoryApi\Api\Data\StockInterface;
+use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
+use Magento\InventorySalesApi\Model\ReturnProcessor\Result\SourceDeductedOrderItemFactory;
+use Magento\InventorySalesApi\Model\ReturnProcessor\Result\SourceDeductedOrderItemsResult;
+use Magento\InventorySalesApi\Model\ReturnProcessor\Result\SourceDeductedOrderItemsResultFactory;
+use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Order\Invoice\Item as InvoiceItem;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Store\Model\Store;
+use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditorInventory\Model\Stock\ReturnProcessor\GetItemsToReturnPerSource;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GetItemsToReturnPerSourceTest extends TestCase
+{
+    /** @var GetSkuFromOrderItemInterface|MockObject */
+    private $getSkuFromOrderItem;
+
+    /** @var StockByWebsiteIdResolverInterface|MockObject */
+    private $stockByWebsiteIdResolver;
+
+    /** @var GetSourcesAssignedToStockOrderedByPriorityInterface|MockObject */
+    private $getSourcesAssignedToStockOrderedByPriority;
+
+    /** @var GetSourceItemsBySkuInterface|MockObject */
+    private $getSourceItemsBySku;
+
+    /** @var DefaultSourceProviderInterface|MockObject */
+    private $defaultSourceProvider;
+
+    /** @var SourceDeductedOrderItemFactory|MockObject */
+    private $sourceDeductedOrderItemFactory;
+
+    /** @var SourceDeductedOrderItemsResultFactory|MockObject */
+    private $sourceDeductedOrderItemsResultFactory;
+
+    private GetItemsToReturnPerSource $processor;
+
+    protected function setUp(): void
+    {
+        $this->getSkuFromOrderItem                        = $this->createMock(GetSkuFromOrderItemInterface::class);
+        $this->stockByWebsiteIdResolver                   = $this->createMock(StockByWebsiteIdResolverInterface::class);
+        $this->getSourcesAssignedToStockOrderedByPriority = $this->createMock(
+            GetSourcesAssignedToStockOrderedByPriorityInterface::class
+        );
+        $this->getSourceItemsBySku                        = $this->createMock(GetSourceItemsBySkuInterface::class);
+        $this->defaultSourceProvider                      = $this->createMock(DefaultSourceProviderInterface::class);
+        $this->sourceDeductedOrderItemFactory             = $this->createMock(SourceDeductedOrderItemFactory::class);
+        $this->sourceDeductedOrderItemsResultFactory      = $this->createMock(
+            SourceDeductedOrderItemsResultFactory::class
+        );
+
+        $this->processor = new GetItemsToReturnPerSource(
+            $this->getSkuFromOrderItem,
+            $this->stockByWebsiteIdResolver,
+            $this->getSourcesAssignedToStockOrderedByPriority,
+            $this->getSourceItemsBySku,
+            $this->defaultSourceProvider,
+            $this->sourceDeductedOrderItemFactory,
+            $this->sourceDeductedOrderItemsResultFactory
+        );
+    }
+
+    public function testRegularOrderIsSkipped(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $this->sourceDeductedOrderItemsResultFactory->expects($this->never())->method('create');
+
+        $result = $this->processor->execute($order, [1, 2]);
+        $this->assertSame([], $result);
+    }
+
+    public function testReturnsHighestPrioritySource(): void
+    {
+        $orderItem = $this->createMock(OrderItem::class);
+        $orderItem->method('getId')->willReturn(11);
+        $orderItem->method('getParentItemId')->willReturn(null);
+        $orderItem->method('isDummy')->willReturn(false);
+
+        $invoiceItem = $this->createMock(InvoiceItem::class);
+        $invoiceItem->method('getOrderItem')->willReturn($orderItem);
+        $invoiceItem->method('getQty')->willReturn(2.0);
+
+        $invoice = $this->createMock(Invoice::class);
+        $invoice->method('getItems')->willReturn([$invoiceItem]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getWebsiteId')->willReturn(1);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getInvoiceCollection')->willReturn([$invoice]);
+        $order->method('getStore')->willReturn($store);
+
+        $this->getSkuFromOrderItem->method('execute')->willReturn('sku-1');
+
+        $stock = $this->createMock(StockInterface::class);
+        $stock->method('getStockId')->willReturn(7);
+        $this->stockByWebsiteIdResolver->method('execute')->with(1)->willReturn($stock);
+
+        $this->defaultSourceProvider->method('getCode')->willReturn('default');
+
+        $available = $this->createMock(SourceItemInterface::class);
+        $available->method('getSourceCode')->willReturn('source-A');
+        $this->getSourceItemsBySku->method('execute')->with('sku-1')->willReturn([$available]);
+
+        $assignedHigh = $this->createMock(SourceInterface::class);
+        $assignedHigh->method('getSourceCode')->willReturn('source-A');
+        $assignedLow = $this->createMock(SourceInterface::class);
+        $assignedLow->method('getSourceCode')->willReturn('source-B');
+        $this->getSourcesAssignedToStockOrderedByPriority->method('execute')
+                                                         ->with(7)
+                                                         ->willReturn([$assignedHigh, $assignedLow]);
+
+        $deductedItem = new \stdClass();
+        $this->sourceDeductedOrderItemFactory->expects($this->once())
+                                             ->method('create')
+                                             ->with(['sku' => 'sku-1', 'quantity' => 2.0])
+                                             ->willReturn($deductedItem);
+
+        $resultObj = $this->createMock(SourceDeductedOrderItemsResult::class);
+        $this->sourceDeductedOrderItemsResultFactory->expects($this->once())
+                                                    ->method('create')
+                                                    ->with(['sourceCode' => 'source-A', 'items' => [$deductedItem]])
+                                                    ->willReturn($resultObj);
+
+        $result = $this->processor->execute($order, [11]);
+        $this->assertSame([$resultObj], $result);
+    }
+
+    public function testItemsNotInReturnListAreSkipped(): void
+    {
+        $orderItem = $this->createMock(OrderItem::class);
+        $orderItem->method('getId')->willReturn(99);
+        $orderItem->method('getParentItemId')->willReturn(null);
+        $orderItem->method('isDummy')->willReturn(false);
+
+        $invoiceItem = $this->createMock(InvoiceItem::class);
+        $invoiceItem->method('getOrderItem')->willReturn($orderItem);
+
+        $invoice = $this->createMock(Invoice::class);
+        $invoice->method('getItems')->willReturn([$invoiceItem]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getWebsiteId')->willReturn(1);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getInvoiceCollection')->willReturn([$invoice]);
+        $order->method('getStore')->willReturn($store);
+
+        $stock = $this->createMock(StockInterface::class);
+        $stock->method('getStockId')->willReturn(1);
+        $this->stockByWebsiteIdResolver->method('execute')->willReturn($stock);
+
+        $this->sourceDeductedOrderItemFactory->expects($this->never())->method('create');
+
+        $result = $this->processor->execute($order, [1]);
+        $this->assertSame([], $result);
+    }
+
+    public function testDummyItemsAreSkipped(): void
+    {
+        $orderItem = $this->createMock(OrderItem::class);
+        $orderItem->method('getId')->willReturn(11);
+        $orderItem->method('isDummy')->willReturn(true);
+
+        $invoiceItem = $this->createMock(InvoiceItem::class);
+        $invoiceItem->method('getOrderItem')->willReturn($orderItem);
+
+        $invoice = $this->createMock(Invoice::class);
+        $invoice->method('getItems')->willReturn([$invoiceItem]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getWebsiteId')->willReturn(1);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getInvoiceCollection')->willReturn([$invoice]);
+        $order->method('getStore')->willReturn($store);
+
+        $stock = $this->createMock(StockInterface::class);
+        $stock->method('getStockId')->willReturn(1);
+        $this->stockByWebsiteIdResolver->method('execute')->willReturn($stock);
+
+        $this->sourceDeductedOrderItemFactory->expects($this->never())->method('create');
+
+        $result = $this->processor->execute($order, [11]);
+        $this->assertSame([], $result);
+    }
+}

--- a/Test/Unit/Model/Stock/SourceCodeResolverTest.php
+++ b/Test/Unit/Model/Stock/SourceCodeResolverTest.php
@@ -1,0 +1,122 @@
+<?php
+/** Copyright © MageWorx. All rights reserved. See LICENSE.txt */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model\Stock;
+
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager as ObjectManagerHelper;
+use Magento\InventoryApi\Api\Data\SourceInterface;
+use Magento\InventoryApi\Api\Data\SourceItemInterface;
+use Magento\InventoryApi\Api\GetSourceItemsBySkuInterface;
+use Magento\InventoryApi\Api\SourceRepositoryInterface;
+use MageWorx\OrderEditorInventory\Model\Stock\SourceCodeResolver;
+use PHPUnit\Framework\TestCase;
+
+class SourceCodeResolverTest extends TestCase
+{
+    private ObjectManagerHelper $omHelper;
+
+    protected function setUp(): void
+    {
+        $this->omHelper = new ObjectManagerHelper($this);
+    }
+
+    /**
+     * @dataProvider isSourceUsableProvider
+     */
+    public function testIsSourceUsable(
+        array $availability,
+        string $sourceCode,
+        float $qtyNeeded,
+        bool $backorderAllowed,
+        bool $expected
+    ): void {
+        $resolver = $this->omHelper->getObject(SourceCodeResolver::class);
+
+        $method = new \ReflectionMethod(SourceCodeResolver::class, 'isSourceUsable');
+        $method->setAccessible(true);
+
+        self::assertSame(
+            $expected,
+            $method->invoke($resolver, $availability, $sourceCode, $qtyNeeded, $backorderAllowed)
+        );
+    }
+
+    /**
+     * @return array<string, array{0: array, 1: string, 2: float, 3: bool, 4: bool}>
+     */
+    public static function isSourceUsableProvider(): array
+    {
+        $enabled = static fn(float $qty): array => ['quantity' => $qty, 'status' => 1, 'source_enabled' => true];
+
+        return [
+            'unknown source'            => [[], 'default', 1.0, false, false],
+            'disabled source'           => [['default' => ['quantity' => 99, 'status' => 1, 'source_enabled' => false]], 'default', 1.0, true, false],
+            'enough qty'                => [['default' => $enabled(5)], 'default', 3.0, false, true],
+            'insufficient, no backorder'=> [['default' => $enabled(1)], 'default', 3.0, false, false],
+            'insufficient, backorder ok'=> [['default' => $enabled(1)], 'default', 3.0, true, true],
+        ];
+    }
+
+    public function testFindReturnSourcePrefersGivenSourceWhenAvailable(): void
+    {
+        $resolver = $this->buildResolverWithSources([
+            'east' => ['qty' => 0.0, 'status' => 2, 'enabled' => true],
+            'west' => ['qty' => 5.0, 'status' => 1, 'enabled' => true],
+        ]);
+
+        self::assertSame('west', $resolver->findReturnSource('sku', 1, 'west'));
+    }
+
+    public function testFindReturnSourceFallsBackToFirstEnabledSource(): void
+    {
+        $resolver = $this->buildResolverWithSources([
+            'east' => ['qty' => 0.0, 'status' => 2, 'enabled' => true],
+            'west' => ['qty' => 5.0, 'status' => 1, 'enabled' => true],
+        ]);
+
+        // No preferred → first enabled/in-stock source wins (insertion order).
+        self::assertSame('east', $resolver->findReturnSource('sku', 1, null));
+    }
+
+    public function testFindReturnSourceReturnsNullWhenNoSources(): void
+    {
+        $resolver = $this->buildResolverWithSources([]);
+
+        self::assertNull($resolver->findReturnSource('sku', 1, null));
+    }
+
+    /**
+     * @param array<string, array{qty: float, status: int, enabled: bool}> $sources
+     */
+    private function buildResolverWithSources(array $sources): SourceCodeResolver
+    {
+        $sourceItems = [];
+        $sourceRepository = $this->createMock(SourceRepositoryInterface::class);
+        $repoMap = [];
+
+        foreach ($sources as $code => $info) {
+            $sourceItem = $this->createMock(SourceItemInterface::class);
+            $sourceItem->method('getSourceCode')->willReturn($code);
+            $sourceItem->method('getQuantity')->willReturn($info['qty']);
+            $sourceItem->method('getStatus')->willReturn($info['status']);
+            $sourceItems[] = $sourceItem;
+
+            $source = $this->createMock(SourceInterface::class);
+            $source->method('isEnabled')->willReturn($info['enabled']);
+            $repoMap[$code] = $source;
+        }
+
+        $sourceRepository->method('get')->willReturnCallback(
+            fn(string $code) => $repoMap[$code] ?? throw new \Magento\Framework\Exception\NoSuchEntityException(__('x'))
+        );
+
+        $getSourceItemsBySku = $this->createMock(GetSourceItemsBySkuInterface::class);
+        $getSourceItemsBySku->method('execute')->willReturn($sourceItems);
+
+        return $this->omHelper->getObject(SourceCodeResolver::class, [
+            'getSourceItemsBySku' => $getSourceItemsBySku,
+            'sourceRepository'    => $sourceRepository,
+        ]);
+    }
+}

--- a/Test/Unit/Model/StockQtyManagerTest.php
+++ b/Test/Unit/Model/StockQtyManagerTest.php
@@ -297,8 +297,7 @@ class StockQtyManagerTest extends TestCase
         $orderItem->method('getProductType')->willReturn('simple');
         $orderItem->method('getOrder')->willReturn($order);
         $orderItem->method('getItemId')->willReturn(99);
-        $orderItem->method('getQtyOrdered')->willReturn(5.0);
-        $orderItem->method('getQtyCanceled')->willReturn(1.0);
+        $orderItem->method('getQtyInvoiced')->willReturn(4.0);
         $orderItem->method('getQtyRefunded')->willReturn(2.0);
 
         $this->getSkuFromOrderItem->method('execute')->with($orderItem)->willReturn('sku-r');
@@ -308,9 +307,10 @@ class StockQtyManagerTest extends TestCase
                                    ->method('create')
                                    ->with(
                                        $this->callback(static function (array $data): bool {
+                                           // native formula: qtyInvoiced(4) - qtyRefunded(2) + returnQty(3) = 5
                                            return $data['sku'] === 'sku-r'
                                                && $data['qty'] === 3.0
-                                               && $data['processedQty'] === 2.0;
+                                               && $data['processedQty'] === 5.0;
                                        })
                                    )
                                    ->willReturn(

--- a/Test/Unit/Model/StockQtyManagerTest.php
+++ b/Test/Unit/Model/StockQtyManagerTest.php
@@ -1,0 +1,437 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Model;
+
+use Magento\Bundle\Model\Product\Type as BundleType;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+use Magento\Framework\Exception\InputException;
+use Magento\InventoryCatalogApi\Model\GetProductTypesBySkusInterface;
+use Magento\InventoryCatalogApi\Model\GetSkusByProductIdsInterface;
+use Magento\InventoryConfigurationApi\Model\IsSourceItemManagementAllowedForProductTypeInterface;
+use Magento\InventorySalesApi\Api\Data\ItemToSellInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterfaceFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionFactory;
+use Magento\InventorySalesApi\Api\Data\SalesEventExtensionInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterface;
+use Magento\InventorySalesApi\Api\Data\SalesEventInterfaceFactory;
+use Magento\InventorySalesApi\Api\PlaceReservationsForSalesEventInterface;
+use Magento\InventorySalesApi\Model\GetSkuFromOrderItemInterface;
+use Magento\InventorySalesApi\Model\ReturnProcessor\ProcessRefundItemsInterface;
+use Magento\InventorySalesApi\Model\ReturnProcessor\Request\ItemsToRefundInterfaceFactory;
+use Magento\InventorySalesApi\Model\StockByWebsiteIdResolverInterface;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use Magento\Store\Api\Data\WebsiteInterface;
+use Magento\Store\Api\WebsiteRepositoryInterface;
+use Magento\Store\Model\Store;
+use MageWorx\OrderEditorInventory\Api\CancelShipmentProcessorInterface;
+use MageWorx\OrderEditorInventory\Model\CheckItemsQuantity;
+use MageWorx\OrderEditorInventory\Model\StockQtyManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class StockQtyManagerTest extends TestCase
+{
+    /** @var PlaceReservationsForSalesEventInterface|MockObject */
+    private $placeReservationsForSalesEvent;
+
+    /** @var GetSkusByProductIdsInterface|MockObject */
+    private $getSkusByProductIds;
+
+    /** @var WebsiteRepositoryInterface|MockObject */
+    private $websiteRepository;
+
+    /** @var SalesChannelInterfaceFactory|MockObject */
+    private $salesChannelFactory;
+
+    /** @var SalesEventInterfaceFactory|MockObject */
+    private $salesEventFactory;
+
+    /** @var ItemToSellInterfaceFactory|MockObject */
+    private $itemsToSellFactory;
+
+    /** @var CheckItemsQuantity|MockObject */
+    private $checkItemsQuantity;
+
+    /** @var StockByWebsiteIdResolverInterface|MockObject */
+    private $stockByWebsiteIdResolver;
+
+    /** @var GetProductTypesBySkusInterface|MockObject */
+    private $getProductTypesBySkus;
+
+    /** @var IsSourceItemManagementAllowedForProductTypeInterface|MockObject */
+    private $isSourceItemManagementAllowed;
+
+    /** @var SalesEventExtensionFactory|MockObject */
+    private $salesEventExtensionFactory;
+
+    /** @var GetSkuFromOrderItemInterface|MockObject */
+    private $getSkuFromOrderItem;
+
+    /** @var ItemsToRefundInterfaceFactory|MockObject */
+    private $itemsToRefundFactory;
+
+    /** @var ProcessRefundItemsInterface|MockObject */
+    private $processRefundItems;
+
+    /** @var OrderRepositoryInterface|MockObject */
+    private $orderRepository;
+
+    /** @var CancelShipmentProcessorInterface|MockObject */
+    private $cancelShipmentProcessor;
+
+    private StockQtyManager $stockQtyManager;
+
+    protected function setUp(): void
+    {
+        $this->placeReservationsForSalesEvent = $this->createMock(PlaceReservationsForSalesEventInterface::class);
+        $this->getSkusByProductIds            = $this->createMock(GetSkusByProductIdsInterface::class);
+        $this->websiteRepository              = $this->createMock(WebsiteRepositoryInterface::class);
+        $this->salesChannelFactory            = $this->createMock(SalesChannelInterfaceFactory::class);
+        $this->salesEventFactory              = $this->createMock(SalesEventInterfaceFactory::class);
+        $this->itemsToSellFactory             = $this->createMock(ItemToSellInterfaceFactory::class);
+        $this->checkItemsQuantity             = $this->createMock(CheckItemsQuantity::class);
+        $this->stockByWebsiteIdResolver       = $this->createMock(StockByWebsiteIdResolverInterface::class);
+        $this->getProductTypesBySkus          = $this->createMock(GetProductTypesBySkusInterface::class);
+        $this->isSourceItemManagementAllowed  = $this->createMock(
+            IsSourceItemManagementAllowedForProductTypeInterface::class
+        );
+        $this->salesEventExtensionFactory     = $this->createMock(SalesEventExtensionFactory::class);
+        $this->getSkuFromOrderItem            = $this->createMock(GetSkuFromOrderItemInterface::class);
+        $this->itemsToRefundFactory           = $this->createMock(ItemsToRefundInterfaceFactory::class);
+        $this->processRefundItems             = $this->createMock(ProcessRefundItemsInterface::class);
+        $this->orderRepository                = $this->createMock(OrderRepositoryInterface::class);
+        $this->cancelShipmentProcessor        = $this->createMock(CancelShipmentProcessorInterface::class);
+
+        $this->stockQtyManager = new StockQtyManager(
+            $this->placeReservationsForSalesEvent,
+            $this->getSkusByProductIds,
+            $this->websiteRepository,
+            $this->salesChannelFactory,
+            $this->salesEventFactory,
+            $this->itemsToSellFactory,
+            $this->checkItemsQuantity,
+            $this->stockByWebsiteIdResolver,
+            $this->getProductTypesBySkus,
+            $this->isSourceItemManagementAllowed,
+            $this->salesEventExtensionFactory,
+            $this->getSkuFromOrderItem,
+            $this->itemsToRefundFactory,
+            $this->processRefundItems,
+            $this->orderRepository,
+            $this->cancelShipmentProcessor
+        );
+    }
+
+    public function testDeductQtyFromStockSimpleProductPlacesReservation(): void
+    {
+        $orderItem = $this->createOrderItemMock(
+            productId: 100,
+            productType: 'simple',
+            qtyOrdered: 3.0,
+            order: $this->createOrderMock(orderId: 5, websiteId: 1)
+        );
+
+        $this->getSkusByProductIds->expects($this->once())
+                                  ->method('execute')
+                                  ->with([100])
+                                  ->willReturn([100 => 'sku-simple']);
+
+        $this->isSourceItemManagementAllowed->expects($this->once())
+                                            ->method('execute')
+                                            ->with('simple')
+                                            ->willReturn(true);
+
+        $this->itemsToSellFactory->expects($this->once())->method('create')->willReturn(
+            $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class)
+        );
+
+        $this->mockWebsiteAndStock(websiteId: 1, websiteCode: 'base', stockId: 1);
+        $this->mockSalesEvent();
+
+        $this->checkItemsQuantity->expects($this->once())
+                                 ->method('execute')
+                                 ->with(['sku-simple' => 3.0], 1);
+
+        $this->placeReservationsForSalesEvent->expects($this->once())->method('execute');
+
+        $this->stockQtyManager->deductQtyFromStock($orderItem);
+    }
+
+    public function testDeductQtyFromStockConfigurableProcessesChildren(): void
+    {
+        $childOrderItem = $this->createOrderItemMock(
+            productId: 200,
+            productType: 'simple',
+            qtyOrdered: 1.0,
+            order: $this->createOrderMock(orderId: 10, websiteId: 1)
+        );
+
+        $parent = $this->createConfiguredMock(OrderItem::class, []);
+        $parent->method('getProductType')->willReturn(Configurable::TYPE_CODE);
+        $parent->method('getChildrenItems')->willReturn([$childOrderItem]);
+        $parent->method('getParentItemId')->willReturn(null);
+
+        $this->getSkusByProductIds->expects($this->once())
+                                  ->method('execute')
+                                  ->with([200])
+                                  ->willReturn([200 => 'sku-child']);
+
+        $this->isSourceItemManagementAllowed->method('execute')->willReturn(true);
+        $this->itemsToSellFactory->method('create')->willReturn(
+            $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class)
+        );
+
+        $this->mockWebsiteAndStock(websiteId: 1, websiteCode: 'base', stockId: 1);
+        $this->mockSalesEvent();
+
+        $this->placeReservationsForSalesEvent->expects($this->once())->method('execute');
+
+        $this->stockQtyManager->deductQtyFromStock($parent);
+    }
+
+    public function testDeductQtyFromStockBundleProcessesChildren(): void
+    {
+        $childOrderItem = $this->createOrderItemMock(
+            productId: 300,
+            productType: 'simple',
+            qtyOrdered: 2.0,
+            order: $this->createOrderMock(orderId: 11, websiteId: 1)
+        );
+
+        $bundle = $this->createConfiguredMock(OrderItem::class, []);
+        $bundle->method('getProductType')->willReturn(BundleType::TYPE_CODE);
+        $bundle->method('getChildrenItems')->willReturn([$childOrderItem]);
+        $bundle->method('getParentItemId')->willReturn(null);
+
+        $this->getSkusByProductIds->expects($this->once())
+                                  ->method('execute')
+                                  ->with([300])
+                                  ->willReturn([300 => 'sku-bundle-child']);
+
+        $this->isSourceItemManagementAllowed->method('execute')->willReturn(true);
+        $this->itemsToSellFactory->method('create')->willReturn(
+            $this->createMock(\Magento\InventorySalesApi\Api\Data\ItemToSellInterface::class)
+        );
+
+        $this->mockWebsiteAndStock(websiteId: 1, websiteCode: 'base', stockId: 1);
+        $this->mockSalesEvent();
+
+        $this->placeReservationsForSalesEvent->expects($this->once())->method('execute');
+
+        $this->stockQtyManager->deductQtyFromStock($bundle);
+    }
+
+    public function testDeductQtyFromStockChildItemSkipped(): void
+    {
+        $child = $this->createConfiguredMock(OrderItem::class, []);
+        $child->method('getProductType')->willReturn('simple');
+        $child->method('getParentItemId')->willReturn(50);
+
+        $this->getSkusByProductIds->expects($this->never())->method('execute');
+        $this->placeReservationsForSalesEvent->expects($this->never())->method('execute');
+
+        $this->stockQtyManager->deductQtyFromStock($child);
+    }
+
+    public function testDeductQtyFromStockThrowsWhenOrderMissing(): void
+    {
+        $orderItem = $this->createConfiguredMock(OrderItem::class, []);
+        $orderItem->method('getProductType')->willReturn('simple');
+        $orderItem->method('getParentItemId')->willReturn(null);
+        $orderItem->method('getProductId')->willReturn(1);
+        $orderItem->method('getQtyOrdered')->willReturn(1.0);
+        $orderItem->method('getOrder')->willReturn(null);
+
+        $this->expectException(InputException::class);
+        $this->stockQtyManager->deductQtyFromStock($orderItem);
+    }
+
+    public function testDeductQtyFromStockSkipsItemsNotAllowedForSourceManagement(): void
+    {
+        $orderItem = $this->createOrderItemMock(
+            productId: 400,
+            productType: 'virtual',
+            qtyOrdered: 1.0,
+            order: $this->createOrderMock(orderId: 12, websiteId: 1)
+        );
+
+        $this->getSkusByProductIds->method('execute')->willReturn([400 => 'sku-virtual']);
+        $this->isSourceItemManagementAllowed->expects($this->once())
+                                            ->method('execute')
+                                            ->with('virtual')
+                                            ->willReturn(false);
+
+        $this->itemsToSellFactory->expects($this->never())->method('create');
+        $this->mockWebsiteAndStock(websiteId: 1, websiteCode: 'base', stockId: 1);
+        $this->mockSalesEvent();
+
+        $this->checkItemsQuantity->expects($this->once())->method('execute')->with([], 1);
+        $this->placeReservationsForSalesEvent->expects($this->once())
+                                             ->method('execute')
+                                             ->with([], $this->anything(), $this->anything());
+
+        $this->stockQtyManager->deductQtyFromStock($orderItem);
+    }
+
+    public function testReturnQtyToStockThrowsWhenOrderMissing(): void
+    {
+        $orderItem = $this->createConfiguredMock(OrderItem::class, []);
+        $orderItem->method('getOrder')->willReturn(null);
+
+        $this->expectException(InputException::class);
+        $this->stockQtyManager->returnQtyToStock($orderItem, 1.0);
+    }
+
+    public function testReturnQtyToStockSimpleProductDelegatesToProcessRefundItems(): void
+    {
+        $order     = $this->createOrderMock(orderId: 20, websiteId: 1);
+        $orderItem = $this->createConfiguredMock(OrderItem::class, []);
+        $orderItem->method('getProductType')->willReturn('simple');
+        $orderItem->method('getOrder')->willReturn($order);
+        $orderItem->method('getItemId')->willReturn(99);
+        $orderItem->method('getQtyOrdered')->willReturn(5.0);
+        $orderItem->method('getQtyCanceled')->willReturn(1.0);
+        $orderItem->method('getQtyRefunded')->willReturn(2.0);
+
+        $this->getSkuFromOrderItem->method('execute')->with($orderItem)->willReturn('sku-r');
+        $this->isSourceItemManagementAllowed->method('execute')->willReturn(true);
+
+        $this->itemsToRefundFactory->expects($this->once())
+                                   ->method('create')
+                                   ->with(
+                                       $this->callback(static function (array $data): bool {
+                                           return $data['sku'] === 'sku-r'
+                                               && $data['qty'] === 3.0
+                                               && $data['processedQty'] === 2.0;
+                                       })
+                                   )
+                                   ->willReturn(
+                                       $this->createMock(
+                                           \Magento\InventorySalesApi\Model\ReturnProcessor\Request\ItemsToRefundInterface::class
+                                       )
+                                   );
+
+        $this->processRefundItems->expects($this->once())
+                                 ->method('execute')
+                                 ->with($order, $this->isType('array'), [99]);
+
+        $this->stockQtyManager->returnQtyToStock($orderItem, -3.0);
+    }
+
+    public function testReturnQtyToStockConfigurableUsesChildren(): void
+    {
+        $order = $this->createOrderMock(orderId: 21, websiteId: 1);
+
+        $child = $this->createConfiguredMock(OrderItem::class, []);
+        $child->method('getProductType')->willReturn('simple');
+        $child->method('getItemId')->willReturn(101);
+        $child->method('getQtyOrdered')->willReturn(4.0);
+        $child->method('getQtyCanceled')->willReturn(0.0);
+        $child->method('getQtyRefunded')->willReturn(0.0);
+
+        $parent = $this->createConfiguredMock(OrderItem::class, []);
+        $parent->method('getProductType')->willReturn(Configurable::TYPE_CODE);
+        $parent->method('getOrder')->willReturn($order);
+        $parent->method('getChildrenItems')->willReturn([$child]);
+
+        $this->getSkuFromOrderItem->method('execute')->willReturn('sku-child');
+        $this->isSourceItemManagementAllowed->method('execute')->willReturn(true);
+        $this->itemsToRefundFactory->method('create')->willReturn(
+            $this->createMock(\Magento\InventorySalesApi\Model\ReturnProcessor\Request\ItemsToRefundInterface::class)
+        );
+
+        $this->processRefundItems->expects($this->once())
+                                 ->method('execute')
+                                 ->with($order, $this->isType('array'), [101]);
+
+        $this->stockQtyManager->returnQtyToStock($parent, -2.0);
+    }
+
+    public function testReturnQtyToStockSkipsInvalidItems(): void
+    {
+        $order     = $this->createOrderMock(orderId: 22, websiteId: 1);
+        $orderItem = $this->createConfiguredMock(OrderItem::class, []);
+        $orderItem->method('getProductType')->willReturn('virtual');
+        $orderItem->method('getOrder')->willReturn($order);
+
+        $this->getSkuFromOrderItem->method('execute')->willReturn('sku-virtual');
+        $this->isSourceItemManagementAllowed->method('execute')->with('virtual')->willReturn(false);
+
+        $this->itemsToRefundFactory->expects($this->never())->method('create');
+        $this->processRefundItems->expects($this->never())->method('execute');
+
+        $this->stockQtyManager->returnQtyToStock($orderItem, -1.0);
+    }
+
+    public function testCancelShipmentDelegatesToProcessor(): void
+    {
+        $shipment = $this->createMock(\Magento\Sales\Api\Data\ShipmentInterface::class);
+        $this->cancelShipmentProcessor->expects($this->once())->method('execute')->with($shipment);
+        $this->stockQtyManager->cancelShipment($shipment);
+    }
+
+    /**
+     * @param int $orderId
+     * @param int $websiteId
+     * @return Order|MockObject
+     */
+    private function createOrderMock(int $orderId, int $websiteId)
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getWebsiteId')->willReturn($websiteId);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn($orderId);
+        $order->method('getEntityId')->willReturn($orderId);
+        $order->method('getIncrementId')->willReturn('100000' . $orderId);
+        $order->method('getStore')->willReturn($store);
+
+        return $order;
+    }
+
+    /**
+     * @return OrderItem|MockObject
+     */
+    private function createOrderItemMock(int $productId, string $productType, float $qtyOrdered, Order $order)
+    {
+        $orderItem = $this->createConfiguredMock(OrderItem::class, []);
+        $orderItem->method('getProductType')->willReturn($productType);
+        $orderItem->method('getParentItemId')->willReturn(null);
+        $orderItem->method('getProductId')->willReturn($productId);
+        $orderItem->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $orderItem->method('getOrder')->willReturn($order);
+
+        return $orderItem;
+    }
+
+    private function mockWebsiteAndStock(int $websiteId, string $websiteCode, int $stockId): void
+    {
+        $website = $this->createMock(WebsiteInterface::class);
+        $website->method('getCode')->willReturn($websiteCode);
+        $this->websiteRepository->method('getById')->with($websiteId)->willReturn($website);
+
+        $stock = $this->createMock(\Magento\InventoryApi\Api\Data\StockInterface::class);
+        $stock->method('getStockId')->willReturn($stockId);
+        $this->stockByWebsiteIdResolver->method('execute')->with($websiteId)->willReturn($stock);
+    }
+
+    private function mockSalesEvent(): void
+    {
+        $extension = $this->createMock(SalesEventExtensionInterface::class);
+        $this->salesEventExtensionFactory->method('create')->willReturn($extension);
+
+        $event = $this->createMock(SalesEventInterface::class);
+        $this->salesEventFactory->method('create')->willReturn($event);
+
+        $channel = $this->createMock(SalesChannelInterface::class);
+        $this->salesChannelFactory->method('create')->willReturn($channel);
+    }
+}

--- a/Test/Unit/Observer/InStorePickupHandlerTest.php
+++ b/Test/Unit/Observer/InStorePickupHandlerTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Inventory\Model\SourceRepository;
+use Magento\InventoryInStorePickupQuote\Model\Address\SetAddressPickupLocation;
+use Magento\InventoryInStorePickupSalesAdminUi\Model\GetShippingAddressBySourceCodeAndOriginalAddress;
+use Magento\InventoryInStorePickupShippingApi\Model\Carrier\GetCarrierTitle;
+use Magento\InventoryInStorePickupShippingApi\Model\Carrier\InStorePickup;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Address as QuoteAddress;
+use Magento\Quote\Model\Quote\Address\ToOrderAddress as ToOrderAddressConverter;
+use Magento\Sales\Api\Data\OrderExtensionFactory;
+use Magento\Sales\Api\Data\OrderExtensionInterface;
+use Magento\Sales\Api\OrderAddressRepositoryInterface;
+use Magento\Sales\Model\Order as SalesOrder;
+use MageWorx\OrderEditor\Model\Order as OrderEditorOrder;
+use MageWorx\OrderEditorInventory\Model\InventoryPickupLocationTableManager;
+use MageWorx\OrderEditorInventory\Observer\InStorePickupHandler;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class InStorePickupHandlerTest extends TestCase
+{
+    /** @var LoggerInterface|MockObject */
+    private $logger;
+
+    /** @var GetCarrierTitle|MockObject */
+    private $getCarrierTitle;
+
+    /** @var SourceRepository|MockObject */
+    private $sourceRepository;
+
+    /** @var CartRepositoryInterface|MockObject */
+    private $cartRepository;
+
+    /** @var OrderExtensionFactory|MockObject */
+    private $orderExtensionFactory;
+
+    /** @var SetAddressPickupLocation|MockObject */
+    private $setAddressPickupLocation;
+
+    /** @var ToOrderAddressConverter|MockObject */
+    private $quoteAddressToOrderAddress;
+
+    /** @var OrderAddressRepositoryInterface|MockObject */
+    private $orderAddressRepository;
+
+    /** @var InventoryPickupLocationTableManager|MockObject */
+    private $tableManager;
+
+    /** @var GetShippingAddressBySourceCodeAndOriginalAddress|MockObject */
+    private $getShippingAddressBySourceCodeAndOriginalAddress;
+
+    private InStorePickupHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->logger                                          = $this->createMock(LoggerInterface::class);
+        $this->getCarrierTitle                                 = $this->createMock(GetCarrierTitle::class);
+        $this->sourceRepository                                = $this->createMock(SourceRepository::class);
+        $this->cartRepository                                  = $this->createMock(CartRepositoryInterface::class);
+        $this->orderExtensionFactory                           = $this->createMock(OrderExtensionFactory::class);
+        $this->setAddressPickupLocation                        = $this->createMock(SetAddressPickupLocation::class);
+        $this->quoteAddressToOrderAddress                      = $this->createMock(ToOrderAddressConverter::class);
+        $this->orderAddressRepository                          = $this->createMock(
+            OrderAddressRepositoryInterface::class
+        );
+        $this->tableManager                                    = $this->createMock(
+            InventoryPickupLocationTableManager::class
+        );
+        $this->getShippingAddressBySourceCodeAndOriginalAddress = $this->createMock(
+            GetShippingAddressBySourceCodeAndOriginalAddress::class
+        );
+
+        $this->handler = new InStorePickupHandler(
+            $this->logger,
+            $this->getCarrierTitle,
+            $this->sourceRepository,
+            $this->cartRepository,
+            $this->orderExtensionFactory,
+            $this->setAddressPickupLocation,
+            $this->quoteAddressToOrderAddress,
+            $this->orderAddressRepository,
+            $this->tableManager,
+            $this->getShippingAddressBySourceCodeAndOriginalAddress
+        );
+    }
+
+    public function testReturnsWhenOrderIsNotMagentoSalesOrder(): void
+    {
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getData')->willReturnMap([
+            ['shipping_method', null, InStorePickup::DELIVERY_METHOD],
+            ['order', null, new \stdClass()],
+        ]);
+
+        $this->cartRepository->expects($this->never())->method('save');
+        $this->tableManager->expects($this->never())->method('removeRowByOrderId');
+
+        $this->handler->execute($observer);
+    }
+
+    public function testNonPickupMethodCleansPickupTables(): void
+    {
+        $quoteAddress = $this->createMock(QuoteAddress::class);
+        $quoteAddress->method('getData')->with('address_id')->willReturn(77);
+
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getShippingAddress')->willReturn($quoteAddress);
+
+        $order = $this->createMock(OrderEditorOrder::class);
+        $order->method('getQuote')->willReturn($quote);
+        $order->method('getEntityId')->willReturn(123);
+
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getData')->willReturnMap([
+            ['shipping_method', null, 'flatrate_flatrate'],
+            ['order', null, $order],
+        ]);
+
+        $this->tableManager->expects($this->once())->method('removeRowByOrderId')->with(123);
+        $this->tableManager->expects($this->once())->method('removeRowByQuoteAddressId')->with(77);
+
+        $this->handler->execute($observer);
+    }
+
+    public function testVirtualQuoteIsSkipped(): void
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('isVirtual')->willReturn(true);
+
+        $order = $this->createMock(OrderEditorOrder::class);
+        $order->method('getQuote')->willReturn($quote);
+
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getData')->willReturnMap([
+            ['shipping_method', null, InStorePickup::DELIVERY_METHOD],
+            ['order', null, $order],
+        ]);
+
+        $this->cartRepository->expects($this->never())->method('save');
+        $this->tableManager->expects($this->never())->method('removeRowByOrderId');
+
+        $this->handler->execute($observer);
+    }
+
+    public function testGetShippingDescriptionConcatenatesCarrierAndMethod(): void
+    {
+        $description = $this->handler->getShippingDescription('In-Store Pickup', 'Main Store');
+        $this->assertSame('In-Store Pickup - Main Store', $description);
+    }
+
+    public function testNonSalesOrderIsIgnoredEvenIfMethodMatches(): void
+    {
+        $observer = $this->createMock(Observer::class);
+        $observer->method('getData')->willReturnMap([
+            ['shipping_method', null, InStorePickup::DELIVERY_METHOD],
+            ['order', null, null],
+        ]);
+
+        $this->cartRepository->expects($this->never())->method('save');
+        $this->handler->execute($observer);
+    }
+}

--- a/Test/Unit/Plugin/SavePickupLocationForOrderPluginTest.php
+++ b/Test/Unit/Plugin/SavePickupLocationForOrderPluginTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types = 1);
+
+namespace MageWorx\OrderEditorInventory\Test\Unit\Plugin;
+
+use Magento\InventoryInStorePickupSales\Model\Order\GetPickupLocationCode;
+use Magento\InventoryInStorePickupSales\Model\ResourceModel\OrderPickupLocation\SaveOrderPickupLocation;
+use MageWorx\OrderEditor\Model\Order;
+use MageWorx\OrderEditor\Model\Order\OrderRepository;
+use MageWorx\OrderEditorInventory\Plugin\SavePickupLocationForOrderPlugin;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SavePickupLocationForOrderPluginTest extends TestCase
+{
+    /** @var SaveOrderPickupLocation|MockObject */
+    private $saveOrderPickupLocation;
+
+    /** @var GetPickupLocationCode|MockObject */
+    private $getPickupLocationCode;
+
+    /** @var OrderRepository|MockObject */
+    private $repository;
+
+    private SavePickupLocationForOrderPlugin $plugin;
+
+    protected function setUp(): void
+    {
+        $this->saveOrderPickupLocation = $this->createMock(SaveOrderPickupLocation::class);
+        $this->getPickupLocationCode   = $this->createMock(GetPickupLocationCode::class);
+        $this->repository              = $this->createMock(OrderRepository::class);
+
+        $this->plugin = new SavePickupLocationForOrderPlugin(
+            $this->saveOrderPickupLocation,
+            $this->getPickupLocationCode
+        );
+    }
+
+    public function testSavesPickupLocationWhenCodeIsPresent(): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getEntityId')->willReturn(42);
+
+        $this->getPickupLocationCode->expects($this->once())
+                                    ->method('execute')
+                                    ->with($order)
+                                    ->willReturn('source-A');
+
+        $this->saveOrderPickupLocation->expects($this->once())
+                                      ->method('execute')
+                                      ->with(42, 'source-A');
+
+        $result = $this->plugin->afterSave($this->repository, $order, $order);
+        $this->assertSame($order, $result);
+    }
+
+    public function testNoOpWhenPickupCodeIsEmpty(): void
+    {
+        $order = $this->createMock(Order::class);
+
+        $this->getPickupLocationCode->method('execute')->willReturn('');
+        $this->saveOrderPickupLocation->expects($this->never())->method('execute');
+
+        $result = $this->plugin->afterSave($this->repository, $order, $order);
+        $this->assertSame($order, $result);
+    }
+
+    public function testNoOpWhenPickupCodeIsNull(): void
+    {
+        $order = $this->createMock(Order::class);
+
+        $this->getPickupLocationCode->method('execute')->willReturn(null);
+        $this->saveOrderPickupLocation->expects($this->never())->method('execute');
+
+        $result = $this->plugin->afterSave($this->repository, $order, $order);
+        $this->assertSame($order, $result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mageworx/module-ordereditor-inventory",
     "description": "Order Editor Inventory Plugin",
     "require": {
-        "mageworx/module-ordereditorbase": ">=2.14.0",
+        "mageworx/module-ordereditorbase": ">=2.15.0",
         "magento/module-inventory": "^1.0",
         "magento/module-inventory-api": "^1.0",
         "magento/module-inventory-sales-api": "^1.0",
@@ -15,7 +15,7 @@
         "magento/module-inventory-in-store-pickup-sales-admin-ui": "^1.0"
     },
     "type": "magento2-module",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,6 +10,9 @@
                 type="MageWorx\OrderEditorInventory\Model\StockQtyManager"/>
     <preference for="MageWorx\OrderEditorInventory\Api\CancelShipmentProcessorInterface"
                 type="MageWorx\OrderEditorInventory\Model\Stock\ReturnProcessor\CancelShipmentProcessor"/>
+    <!-- Override the no-op fallback from OrderEditor with the real MSI exchange -->
+    <preference for="MageWorx\OrderEditor\Api\Stock\SwapPhysicalExchangeInterface"
+                type="MageWorx\OrderEditorInventory\Model\Stock\MsiSwapPhysicalExchange"/>
     <type name="MageWorx\OrderEditor\Model\Order\Item">
         <arguments>
             <argument name="stockManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Stock\MultiSourceInventoryManager</argument>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -38,8 +38,17 @@
             </argument>
         </arguments>
     </type>
-    <!-- Shipment manager with MSI support -->
+    <!-- Shipment manager with MSI support — must be injected into BOTH sales
+         processors. Without it a processor falls back to the non-MSI
+         ShipmentManager, whose removeAllShipments() deletes shipments without
+         returning stock, so a "delete & create new shipment" edit double-deducts
+         the still-shipped qty (source drift). -->
     <type name="MageWorx\OrderEditor\Model\Order\SalesProcessor\DeleteAndCreateSalesProcessor">
+        <arguments>
+            <argument name="shipmentManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Order\ShipmentManager</argument>
+        </arguments>
+    </type>
+    <type name="MageWorx\OrderEditor\Model\Order\SalesProcessor\KeepUntouchedSalesProcessor">
         <arguments>
             <argument name="shipmentManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Order\ShipmentManager</argument>
         </arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,6 +15,12 @@
             <argument name="stockManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Stock\MultiSourceInventoryManager</argument>
         </arguments>
     </type>
+    <!-- Inject MSI stock manager into the new StockService -->
+    <type name="MageWorx\OrderEditor\Model\Order\Item\StockService">
+        <arguments>
+            <argument name="stockManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Stock\MultiSourceInventoryManager</argument>
+        </arguments>
+    </type>
     <!-- Support for editing the order pickup location -->
     <type name="MageWorx\OrderEditor\Model\Order\OrderRepository">
         <plugin name="MageWorx_OrderEditor::SavePickupLocationForOrder"
@@ -30,7 +36,7 @@
         </arguments>
     </type>
     <!-- Shipment manager with MSI support -->
-    <type name="MageWorx\OrderEditor\Model\Order\Sales">
+    <type name="MageWorx\OrderEditor\Model\Order\SalesProcessor\DeleteAndCreateSalesProcessor">
         <arguments>
             <argument name="shipmentManager" xsi:type="object">MageWorx\OrderEditorInventory\Model\Order\ShipmentManager</argument>
         </arguments>


### PR DESCRIPTION
Companion to MageWorx_OrderEditor `refactoring_march`.

**Refactor:** extract MSI/stock logic from StockQtyManager into focused classes —
`BackorderPolicy`, `SourceCodeResolver`, `MsiSwapPhysicalExchange`.

**Fixes:**
- §4.2.3 — paired MSI reservations for swapped-in SKU on Configure.
- §4.2.6 — reservation-only mode in `registerReturnByProductId` (with order).
- StockQtyManager: align returned `processedQty` with native MSI formula.

**Tests:** new unit suite (StockQtyManager, MultiSourceInventoryManager,
MsiSwapPhysicalExchange, BackorderPolicy, SourceCodeResolver,
GetItemsToReturnPerSource, ShipmentManager, InStorePickupHandler, …).